### PR TITLE
Support NeuroLucida soma stacks

### DIFF
--- a/include/morphio/errorMessages.h
+++ b/include/morphio/errorMessages.h
@@ -141,8 +141,7 @@ public:
     ////////////////////////////////////////////////////////////////////////////////
     //             NEUROLUCIDA
     ////////////////////////////////////////////////////////////////////////////////
-    const std::string ERROR_SOMA_ALREADY_DEFINED(int lineNumber) const;
-
+    const std::string ERROR_MULTIPLE_SOMA_STACKS_WITH_SAME_Z(int line1, int line2, float z) const;
 
     const std::string ERROR_PARSING_POINT(int lineNumber,
                                           const std::string& point) const;

--- a/src/errorMessages.cpp
+++ b/src/errorMessages.cpp
@@ -143,9 +143,15 @@ const std::string _col(float val1, float val2) {
 ////////////////////////////////////////////////////////////////////////////////
 //             NEUROLUCIDA
 ////////////////////////////////////////////////////////////////////////////////
-const std::string ErrorMessages::ERROR_SOMA_ALREADY_DEFINED(int lineNumber) const {
-    return errorMsg(lineNumber, ErrorLevel::ERROR,
-                    "A soma is already defined");
+const std::string ErrorMessages::ERROR_MULTIPLE_SOMA_STACKS_WITH_SAME_Z(int line1, int line2, float z) const {
+    std::string msg = errorMsg(line1, ErrorLevel::ERROR,
+                               "\nThere is already a soma stack for Z == "+std::to_string(z) + " at line:");
+    msg += errorMsg(line2, ErrorLevel::INFO, "");
+    msg += "\nNote: Multiple blocks of type CellBody means the soma is represented as a soma stack.\n"
+        "(More info on soma stacks: https://www.neuron.yale.edu/phpBB/viewtopic.php?t=3833)\n"
+        "In this case, each CellBody block is the soma contour for a given Z position\n"
+        " and each block must have a different Z value";
+    return msg;
 }
 
 

--- a/tests/test_2_neurolucida.py
+++ b/tests/test_2_neurolucida.py
@@ -55,26 +55,6 @@ def test_unfinished_point():
                         ':4:error')
 
 
-def test_multiple_soma():
-    _test_asc_exception('''
-                             ("CellBody"
-                             (Color Red)
-                             (CellBody)
-                             (1 1 0 1 S1)
-                             (-1 1 0 1 S2)
-                             )
-
-                            ("CellBody"
-                             (Color Red)
-                             (CellBody)
-                             (1 1 0 1 S1)
-                             (-1 1 0 1 S2)
-                             )''',
-                        SomaError,
-                        'A soma is already defined',
-                        ':14:error')
-
-
 def test_single_neurite_no_soma():
     with tmp_asc_file('''
                       ( (Color Yellow)
@@ -515,4 +495,75 @@ def test_markers():
                                      [-269.77,  -129.47,   -22.57],
                                      [-268.17,  -130.62,   -24.75],
                                      [-266.79,  -131.77,   -26.13]],
+                                    dtype=np.float32))
+
+
+def test_multiple_soma_stack():
+    _test_asc_exception('''
+(
+  (CellBody)
+  (    5.55     5.05    1.0     2.35)
+  (    2.86     5.72    1.0     2.35)
+)
+
+(
+  (CellBody)
+  (    0.84     1.52   2.0     2.35)
+  (   -4.54     2.36   2.0     2.35)
+  (   -6.55     0.17   10.0     2.35) ; Wrong Z
+)
+''',
+                        RawDataError,
+                        "Soma stack has multiple Z levels:",
+''' * 10.000000
+ * 2.000000'''
+)
+
+    _test_asc_exception('''
+(
+  (CellBody)
+  (    5.88     0.84    1.0     2.35)
+  (    6.05     2.53    1.0     2.35)
+  (    6.39     4.38    1.0     2.35)
+)
+
+(
+  (CellBody)
+  (    1.85     0.67   1.0     2.35)
+  (    0.84     1.52   1.0     2.35)
+  (   -4.54     2.36   1.0     2.35)
+)
+''',
+                        RawDataError,
+                        ':11:error',
+                        'There is already a soma stack for Z == 1.000000 at line:',
+                        ':4:info'
+)
+
+    with tmp_asc_file('''
+(
+  (CellBody)
+  (    5.88     0.84    1.0     2.35)
+  (    6.05     2.53    1.0     2.35)
+  (    6.39     4.38    1.0     2.35)
+)
+
+(
+  (CellBody)
+  (    1.85     0.67   2.0     2.35)
+  (    0.84     1.52   2.0     2.35)
+  (   -4.54     2.36   2.0     2.35)
+)
+''') as tmp_file:
+        m = Morphology(tmp_file.name)
+        assert_array_equal(m.soma.points,
+                           np.array([[ 5.88,  0.84,  1.  ],
+                                     [ 6.05,  2.53,  1.  ],
+                                     [ 6.39,  4.38,  1.  ],
+                                     [ 1.85,  0.67,  2.  ],
+                                     [ 0.84,  1.52,  2.  ],
+                                     [-4.54,  2.36,  2.  ]],
+                                    dtype=np.float32))
+        assert_array_equal(m.soma.diameters,
+                           np.array([2.35] * 6,
                                     dtype=np.float32))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -66,17 +66,24 @@ def assert_string_equal(str1, str2):
         str1.join(sep), str2.join(sep)))
 
 
-def _test_exception(content, exception, str1, str2, extension):
-    '''Create tempfile with given content and check that the exception is raised'''
-    with _tmp_file(content, extension) as tmp_file:
+def _test_swc_exception(content, exception, *messages):
+    '''Create tempfile with given content, check that the exception is raised
+    and that messages are part of the error message'''
+    with _tmp_file(content, 'swc') as tmp_file:
         with assert_raises(exception) as obj:
             Morphology(tmp_file.name)
-        assert_substring(str1, str(obj.exception))
-        assert_substring(str2, str(obj.exception))
+        for msg in messages:
+            assert_substring(msg, str(obj.exception))
 
+def _test_asc_exception(content, exception, *messages):
+    '''Create tempfile with given content, check that the exception is raised
+    and that messages are part of the error message'''
+    with _tmp_file(content, 'asc') as tmp_file:
+        with assert_raises(exception) as obj:
+            Morphology(tmp_file.name)
+        for msg in messages:
+            assert_substring(msg, str(obj.exception))
 
-_test_asc_exception = partial(_test_exception, extension='asc')
-_test_swc_exception = partial(_test_exception, extension='swc')
 
 
 @contextmanager


### PR DESCRIPTION
In NeuroLucida, soma stacks are defined by multiple CellBody S-exps, with
each of them being the soma contour at a given Z altitude.
This commits adds support to this representation by concatenating the points
from each stack into the final vector of points.

Fixes https://github.com/BlueBrain/MorphIO/issues/15