### PR TITLE
Return all sections.

### DIFF
--- a/include/morphio/morphology.h
+++ b/include/morphio/morphology.h
@@ -78,8 +78,6 @@ public:
 
     /**
      * Return a vector containing all section objects.
-     *
-     * The first section of the vector is always the soma section.
      **/
     const std::vector<Section> sections() const;
 

--- a/src/morphology.cpp
+++ b/src/morphology.cpp
@@ -129,9 +129,10 @@ const std::vector<Section> Morphology::sections() const
 {
     // TODO: Make this more performant when needed
     std::vector<Section> sections_;
-    for (uint i = 0; i < _properties->get<morphio::Property::Section>().size();
-         ++i) {
-        sections_.push_back(section(i));
+    auto count = _properties->get<morphio::Property::Section>().size();
+    sections_.reserve(count);
+    for (uint i = 0; i < count; ++i) {
+        sections_.emplace_back(section(i));
     }
     return sections_;
 }

--- a/src/morphology.cpp
+++ b/src/morphology.cpp
@@ -129,7 +129,7 @@ const std::vector<Section> Morphology::sections() const
 {
     // TODO: Make this more performant when needed
     std::vector<Section> sections_;
-    for (uint i = 1; i < _properties->get<morphio::Property::Section>().size();
+    for (uint i = 0; i < _properties->get<morphio::Property::Section>().size();
          ++i) {
         sections_.push_back(section(i));
     }

--- a/tests/test_3_h5.py
+++ b/tests/test_3_h5.py
@@ -22,6 +22,7 @@ def test_v1():
     assert_equal(n.version, MORPHOLOGY_VERSION_H5_1)
 
 
+    assert_equal(len(n.sections), 84)
     assert_equal(len(n.soma.points), 3)
     assert_equal(len(list(n.iter())), 84)
     assert_equal(len(n.points), 924)
@@ -54,6 +55,7 @@ def test_v2():
     assert_equal(n.root_sections[1].type, 4)
     assert_equal(len(list(n.iter())), 85)
     assert_equal(len(n.points), 926)
+    assert_equal(len(n.sections), 85)
 
 def test_soma_no_neurite():
     n = Morphology(os.path.join(H5V1_PATH, 'soma_no_neurites.h5'))


### PR DESCRIPTION
Somehow the first of the branches was skipped when returning sections from immutable morphologies.