### PR TITLE
WIP: add some distance fields.

### DIFF
--- a/binds/python/bind_immutable.cpp
+++ b/binds/python/bind_immutable.cpp
@@ -155,7 +155,10 @@ static void bind_immutable_module(py::module &m) {
         // Topology-related member functions
         .def_property_readonly("parent", &morphio::Section::parent,
                                "Returns the parent section of this section\n"
-                               "throw MissingParentError is the section doesn't have a parent")
+                               "throw MissingParentError if the section doesn't have a parent")
+        .def_property_readonly("ancestors", &morphio::Section::ancestors,
+                               "Returns the ancestor sections of this section\n"
+                               "throw MissingParentError if the section does not have ancestors")
         .def_property_readonly("is_root", &morphio::Section::isRoot,
                                "Returns true if this section is a root section (parent ID == -1)")
         .def_property_readonly("children", &morphio::Section::children,
@@ -172,6 +175,8 @@ static void bind_immutable_module(py::module &m) {
                                "Returns list of section's point coordinates")
         .def_property_readonly("diameters", [](morphio::Section* section){ return span_to_ndarray(section->diameters()); },
                                "Returns list of section's point diameters")
+        .def_property_readonly("distances", [](morphio::Section* section){ return span_to_ndarray(section->distances()); },
+                               "Returns list of section's point distances")
         .def_property_readonly("perimeters", [](morphio::Section* section){ return span_to_ndarray(section->perimeters()); },
                                "Returns list of section's point perimeters")
 

--- a/include/morphio/properties.h
+++ b/include/morphio/properties.h
@@ -56,12 +56,22 @@ struct SectionType
     using Type = morphio::SectionType;
 };
 
+struct SectionPathLength
+{
+    using Type = float;
+};
+
 struct Perimeter
 {
     using Type = float;
 };
 
 struct Diameter
+{
+    using Type = float;
+};
+
+struct PathLength
 {
     using Type = float;
 };
@@ -85,6 +95,7 @@ struct PointLevel
 {
     std::vector<Point::Type> _points;
     std::vector<Diameter::Type> _diameters;
+    std::vector<PathLength::Type> _pathLengths;
     std::vector<Perimeter::Type> _perimeters;
 
     PointLevel() {}
@@ -102,6 +113,8 @@ struct SectionLevel
 {
     std::vector<Section::Type> _sections;
     std::vector<SectionType::Type> _sectionTypes;
+    std::vector<SectionPathLength::Type> _pathLengths;
+    std::map<int, std::vector<unsigned int>> _ancestors;
     std::map<int, std::vector<unsigned int>> _children;
 
     bool operator==(const SectionLevel& other) const;
@@ -142,6 +155,7 @@ struct MitochondriaPointLevel
 struct MitochondriaSectionLevel
 {
     std::vector<Section::Type> _sections;
+    std::map<int, std::vector<unsigned int>> _ancestors;
     std::map<int, std::vector<unsigned int>> _children;
 
     bool diff(const MitochondriaSectionLevel& other, LogLevel logLevel) const;

--- a/include/morphio/section.h
+++ b/include/morphio/section.h
@@ -84,6 +84,13 @@ public:
 
     /**
      * Return a view
+    (https://github.com/isocpp/CppCoreGuidelines/blob/master/docs/gsl-intro.md#gslspan-what-is-gslspan-and-what-is-it-for)
+     to the distances of the points from the beginning of this section
+    **/
+    const range<const float> distances() const;
+
+    /**
+     * Return a view
      (https://github.com/isocpp/CppCoreGuidelines/blob/master/docs/gsl-intro.md#gslspan-what-is-gslspan-and-what-is-it-for)
      to this section's point perimeters
      **/

--- a/include/morphio/section_base.h
+++ b/include/morphio/section_base.h
@@ -45,6 +45,11 @@ public:
      */
     const std::vector<T> children() const;
 
+    /**
+     * Return a list of ancestor sections
+     */
+    const std::vector<T> ancestors() const;
+
     /** Return the ID of this section. */
     uint32_t id() const;
 

--- a/include/morphio/section_base.tpp
+++ b/include/morphio/section_base.tpp
@@ -95,6 +95,22 @@ T SectionBase<T>::parent() const
 }
 
 template <typename T>
+const std::vector<T> SectionBase<T>::ancestors() const
+{
+    std::vector<T> result;
+    try {
+        const std::vector<uint32_t>& _ancestors = _properties->ancestors<typename T::SectionId>().at(static_cast<int>(_id));
+        result.reserve(_ancestors.size());
+        for (const uint32_t id_ : _ancestors)
+            result.push_back(T(id_, _properties));
+
+        return result;
+    } catch (const std::out_of_range&) {
+        return result;
+    }
+}
+
+template <typename T>
 const std::vector<T> SectionBase<T>::children() const
 {
     std::vector<T> result;

--- a/src/section.cpp
+++ b/src/section.cpp
@@ -61,6 +61,11 @@ upstream_iterator Section::upstream_end() const
     return upstream_iterator();
 }
 
+const range<const float> Section::distances() const
+{
+    return get<Property::Distance>();
+}
+
 const range<const Point> Section::points() const
 {
     return get<Property::Point>();


### PR DESCRIPTION
Initial work for additional functionality:
```
Section::ancestors(); // Section IDs for parent, parent's parent etc
Section::cumulativePathLength(size_t index); // cumulative length up to point `index`, possibly including all ancestor sections
```

This should be structured differently to keep the original idea of MorphIO as pure library; Values should be calculated only once and cached to avoid expensive computations.