### PR TITLE
Better error message for unsupported section types

### DIFF
--- a/include/morphio/errorMessages.h
+++ b/include/morphio/errorMessages.h
@@ -75,10 +75,6 @@ struct Sample
 
         type = static_cast<SectionType>(int_type);
         diameter = radius * 2; // The point array stores diameters.
-
-        if (type >= SECTION_CUSTOM_START)
-            valid = false; // Unknown section type, custom samples are also
-                           // Regarded as unknown.
     }
 
     float diameter;
@@ -132,6 +128,9 @@ public:
     const std::string ERROR_OPENING_FILE() const;
 
     const std::string ERROR_LINE_NON_PARSABLE(long unsigned int lineNumber) const;
+
+    const std::string ERROR_UNSUPPORTED_SECTION_TYPE(long unsigned int lineNumber,
+                                                     const SectionType& type) const;
 
     const std::string ERROR_MULTIPLE_SOMATA(
         const std::vector<Sample>& somata) const;

--- a/src/errorMessages.cpp
+++ b/src/errorMessages.cpp
@@ -78,6 +78,13 @@ const std::string ErrorMessages::ERROR_LINE_NON_PARSABLE(long unsigned int lineN
     return errorMsg(lineNumber, ErrorLevel::ERROR, "Unable to parse this line");
 }
 
+const std::string ErrorMessages::ERROR_UNSUPPORTED_SECTION_TYPE(long unsigned int lineNumber,
+                                                                const SectionType& type) const
+{
+    return errorMsg(lineNumber, ErrorLevel::ERROR,
+                    "Unsupported section type: " + std::to_string(type));
+}
+
 const std::string ErrorMessages::ERROR_MULTIPLE_SOMATA(
     const std::vector<Sample>& somata) const
 {

--- a/src/plugin/morphologySWC.cpp
+++ b/src/plugin/morphologySWC.cpp
@@ -66,7 +66,11 @@ public:
             const auto& sample = Sample(line.data(), lineNumber);
             if (!sample.valid)
                 LBTHROW(morphio::RawDataError(
-                    err.ERROR_LINE_NON_PARSABLE(lineNumber)));
+                            err.ERROR_LINE_NON_PARSABLE(lineNumber)));
+
+            if (sample.type >= SECTION_CUSTOM_START)
+                LBTHROW(morphio::RawDataError(
+                            err.ERROR_UNSUPPORTED_SECTION_TYPE(lineNumber, sample.type)));
 
             if (samples.count(sample.id) > 0)
                 LBTHROW(morphio::RawDataError(

--- a/tests/test_1_swc.py
+++ b/tests/test_1_swc.py
@@ -400,3 +400,20 @@ def test_read_duplicate():
     assert_array_equal(child1.diameters, np.array([1, 1]))
     assert_array_equal(child2.diameters, np.array([4.6, 7], dtype=np.float32))
     assert_array_equal(child3.diameters, np.array([1, 4.6, 7], dtype=np.float32))
+
+
+def test_unsupported_section_type():
+    with tmp_swc_file('''1 1 0 4 0 3.0 -1
+                         2 3 0 0 2 0.5 1
+                         3 5 0 0 3 0.5 2  # <-- 5 is unsupported section type
+                         ''') as tmp_file:
+
+        with assert_raises(RawDataError) as obj:
+            Morphology(tmp_file.name)
+    assert_substring(
+        '.swc:3:error',
+        strip_color_codes(str(obj.exception)))
+
+    assert_substring(
+        'Unsupported section type: 5',
+        strip_color_codes(str(obj.exception)))


### PR DESCRIPTION
When an SWC file had an unsupported section type, the error message used to be
"Unable to parse this line"

Replaced by:
"Unsupported section type"