### PR TITLE
Remove morphio::Section::length()

### DIFF
--- a/binds/python/bind_misc.cpp
+++ b/binds/python/bind_misc.cpp
@@ -218,13 +218,13 @@ static void bind_misc(py::module &m) {
 
 
   m.def("diff", static_cast<bool (*)(const morphio::Morphology& left, const morphio::Morphology& right, morphio::enums::LogLevel logLevel)>(&morphio::diff),
-        "Perform a diff on 2 morphologies", "left"_a, "right"_a, "log_level"_a=morphio::enums::LogLevel::INFO);
+        "Perform a diff on 2 morphologies, returns True if items differ", "left"_a, "right"_a, "log_level"_a=morphio::enums::LogLevel::INFO);
   m.def("diff", static_cast<bool (*)(const morphio::Section& left, const morphio::Section& right, morphio::enums::LogLevel logLevel)>(&morphio::diff),
-        "Perform a diff on 2 sections", "left"_a, "right"_a, "log_level"_a=morphio::enums::LogLevel::INFO);
+        "Perform a diff on 2 sections, returns True if items differ", "left"_a, "right"_a, "log_level"_a=morphio::enums::LogLevel::INFO);
 
   m.def("diff", static_cast<bool (*)(const morphio::mut::Morphology& left, const morphio::mut::Morphology& right, morphio::enums::LogLevel logLevel)>(&morphio::mut::diff),
-        "Perform a diff on 2 morphologies", "left"_a, "right"_a, "log_level"_a=morphio::enums::LogLevel::INFO);
+        "Perform a diff on 2 morphologies, returns True if items differ", "left"_a, "right"_a, "log_level"_a=morphio::enums::LogLevel::INFO);
   m.def("diff", static_cast<bool (*)(const morphio::mut::Section& left, const morphio::mut::Section& right, morphio::enums::LogLevel logLevel)>(&morphio::mut::diff),
-        "Perform a diff on 2 sections", "left"_a, "right"_a, "log_level"_a=morphio::enums::LogLevel::INFO);
+        "Perform a diff on 2 sections, returns True if items differ", "left"_a, "right"_a, "log_level"_a=morphio::enums::LogLevel::INFO);
 
 }

--- a/include/morphio/section.h
+++ b/include/morphio/section.h
@@ -46,11 +46,6 @@ public:
     bool operator!=(const Section& other) const;
 
     /**
-       Euclidian distance between first and last point of the section
-    **/
-    float length() const;
-
-    /**
        Depth first search iterator
     **/
     depth_iterator depth_begin() const;

--- a/include/morphio/tools.h
+++ b/include/morphio/tools.h
@@ -4,24 +4,24 @@ namespace morphio
 {
 
 /**
-   Perform a diff on 2 morphologies
+   Perform a diff on 2 morphologies, returns True if items differ
 **/
 bool diff(const Morphology& left, const Morphology& right, morphio::enums::LogLevel verbose=morphio::enums::LogLevel::INFO);
 
 /**
-   Perform a diff on 2 sections
+   Perform a diff on 2 sections, returns True if items differ
 **/
 bool diff(const Section& left, const Section& right, morphio::enums::LogLevel verbose=morphio::enums::LogLevel::INFO);
 
 namespace mut
 {
 /**
-   Perform a diff on 2 morphologies
+   Perform a diff on 2 morphologies, returns True if items differ
 **/
 bool diff(const Morphology& left, const Morphology& right, morphio::enums::LogLevel verbose=morphio::enums::LogLevel::INFO);
 
 /**
-   Perform a diff on 2 sections
+   Perform a diff on 2 sections, returns True if items differ
 **/
 bool diff(const Section& left, const Section& right, morphio::enums::LogLevel verbose=morphio::enums::LogLevel::INFO);
 }

--- a/src/section.cpp
+++ b/src/section.cpp
@@ -21,16 +21,6 @@ SectionType Section::type() const
     return val;
 }
 
-float Section::length() const
-{
-    auto points_ = this->points();
-    if (points_.size() < 2)
-        return 0;
-
-    size_t last = points_.size() - 1;
-    return distance(points_[0], points_[last]);
-}
-
 depth_iterator Section::depth_begin() const
 {
     return depth_iterator(*this);


### PR DESCRIPTION
1) It was confusing because it was euclidian length and not pathlength
2) It was not even exposed in the binding
3) It will be in the higher-level library

And fix a few docstrings