### PR TITLE
Make Iterator::Iterator() public and remove IterType from enums.h

### DIFF
--- a/binds/python/bind_enums.h
+++ b/binds/python/bind_enums.h
@@ -1,0 +1,11 @@
+/**
+   A place for enums that are only used in the bindings
+**/
+#pragma once
+
+enum IterType
+{
+    DEPTH_FIRST,
+    BREADTH_FIRST,
+    UPSTREAM
+};

--- a/binds/python/bind_immutable.cpp
+++ b/binds/python/bind_immutable.cpp
@@ -9,6 +9,8 @@
 #include <morphio/enums.h>
 #include <morphio/mut/morphology.h>
 
+#include "bind_enums.h"
+
 namespace py = pybind11;
 
 static void bind_immutable_module(py::module &m) {

--- a/binds/python/bind_immutable.cpp
+++ b/binds/python/bind_immutable.cpp
@@ -90,13 +90,13 @@ static void bind_immutable_module(py::module &m) {
                                "Returns the version")
 
         // Iterators
-        .def("iter", [](morphio::Morphology* morpho, morphio::IterType type) {
+        .def("iter", [](morphio::Morphology* morpho, IterType type) {
                 switch (type) {
-                case morphio::IterType::DEPTH_FIRST:
+                case IterType::DEPTH_FIRST:
                     return py::make_iterator(morpho->depth_begin(), morpho->depth_end());
-                case morphio::IterType::BREADTH_FIRST:
+                case IterType::BREADTH_FIRST:
                     return py::make_iterator(morpho->breadth_begin(), morpho->breadth_end());
-                case morphio::IterType::UPSTREAM:
+                case IterType::UPSTREAM:
                 default:
                     LBTHROW(morphio::MorphioError("Only iteration types depth_first and breadth_first are supported"));
                 }
@@ -106,7 +106,7 @@ static void bind_immutable_module(py::module &m) {
             "iter_type controls the order of iteration on sections of a given neurite. 2 values can be passed:\n"
             "- morphio.IterType.depth_first (default)\n"
             "- morphio.IterType.breadth_first (default)\n"
-            "iter_type"_a=morphio::IterType::DEPTH_FIRST);
+            "iter_type"_a=IterType::DEPTH_FIRST);
 
 
 
@@ -176,13 +176,13 @@ static void bind_immutable_module(py::module &m) {
                                "Returns list of section's point perimeters")
 
         // Iterators
-        .def("iter", [](morphio::Section* section, morphio::IterType type) {
+        .def("iter", [](morphio::Section* section, IterType type) {
                 switch (type) {
-                case morphio::IterType::DEPTH_FIRST:
+                case IterType::DEPTH_FIRST:
                     return py::make_iterator(section->depth_begin(), section->depth_end());
-                case morphio::IterType::BREADTH_FIRST:
+                case IterType::BREADTH_FIRST:
                     return py::make_iterator(section->breadth_begin(), section->breadth_end());
-                case morphio::IterType::UPSTREAM:
+                case IterType::UPSTREAM:
                     return py::make_iterator(section->upstream_begin(), section->upstream_end());
                 default:
                     LBTHROW(morphio::MorphioError("Only iteration types depth_first, breadth_first and upstream are supported"));
@@ -195,7 +195,7 @@ static void bind_immutable_module(py::module &m) {
             "- morphio.IterType.depth_first (default)\n"
             "- morphio.IterType.breadth_first\n"
             "- morphio.IterType.upstream\n",
-            "iter_type"_a=morphio::IterType::DEPTH_FIRST);
+            "iter_type"_a=IterType::DEPTH_FIRST);
 
 
     py::class_<morphio::MitoSection>(m, "MitoSection")
@@ -226,13 +226,13 @@ static void bind_immutable_module(py::module &m) {
                                "end of the neuronal section\n")
 
         // Iterators
-        .def("iter", [](morphio::MitoSection* section, morphio::IterType type) {
+        .def("iter", [](morphio::MitoSection* section, IterType type) {
                 switch (type) {
-                case morphio::IterType::DEPTH_FIRST:
+                case IterType::DEPTH_FIRST:
                     return py::make_iterator(section->depth_begin(), section->depth_end());
-                case morphio::IterType::BREADTH_FIRST:
+                case IterType::BREADTH_FIRST:
                     return py::make_iterator(section->breadth_begin(), section->breadth_end());
-                case morphio::IterType::UPSTREAM:
+                case IterType::UPSTREAM:
                     return py::make_iterator(section->upstream_begin(), section->upstream_end());
                 default:
                     LBTHROW(morphio::MorphioError("Only iteration types depth_first, breadth_first and upstream are supported"));
@@ -243,6 +243,6 @@ static void bind_immutable_module(py::module &m) {
             "\n"
             "If id == -1, the iteration will be successively performed starting\n"
             "at each root section",
-            "iter_type"_a=morphio::IterType::DEPTH_FIRST);
+            "iter_type"_a=IterType::DEPTH_FIRST);
 
 }

--- a/binds/python/bind_misc.cpp
+++ b/binds/python/bind_misc.cpp
@@ -27,14 +27,7 @@ static void bind_misc(py::module &m) {
         .value("single_child", morphio::enums::AnnotationType::SINGLE_CHILD,
             "Indicates that a section has only one child");
 
-    enum IterType
-    {
-        DEPTH_FIRST,
-        BREADTH_FIRST,
-        UPSTREAM
-    };
-
-    py::enum_<morphio::enums::IterType>(m, "IterType")
+    py::enum_<IterType>(m, "IterType")
         .value("depth_first", IterType::DEPTH_FIRST)
         .value("breadth_first", IterType::BREADTH_FIRST)
         .value("upstream", IterType::UPSTREAM)

--- a/binds/python/bind_misc.cpp
+++ b/binds/python/bind_misc.cpp
@@ -27,10 +27,17 @@ static void bind_misc(py::module &m) {
         .value("single_child", morphio::enums::AnnotationType::SINGLE_CHILD,
             "Indicates that a section has only one child");
 
+    enum IterType
+    {
+        DEPTH_FIRST,
+        BREADTH_FIRST,
+        UPSTREAM
+    };
+
     py::enum_<morphio::enums::IterType>(m, "IterType")
-        .value("depth_first", morphio::enums::IterType::DEPTH_FIRST)
-        .value("breadth_first", morphio::enums::IterType::BREADTH_FIRST)
-        .value("upstream", morphio::enums::IterType::UPSTREAM)
+        .value("depth_first", IterType::DEPTH_FIRST)
+        .value("breadth_first", IterType::BREADTH_FIRST)
+        .value("upstream", IterType::UPSTREAM)
         .export_values();
 
     py::enum_<morphio::enums::LogLevel>(m, "LogLevel")

--- a/binds/python/bind_misc.cpp
+++ b/binds/python/bind_misc.cpp
@@ -9,6 +9,8 @@
 #include <morphio/enums.h>
 #include <morphio/tools.h>
 
+#include "bind_enums.h"
+
 namespace py = pybind11;
 
 static void bind_misc(py::module &m) {

--- a/binds/python/bind_mutable.cpp
+++ b/binds/python/bind_mutable.cpp
@@ -88,13 +88,13 @@ static void bind_mutable_module(py::module &m) {
              "Write file to H5, SWC, ASC format depending on filename extension", "filename"_a)
 
         // Iterators
-        .def("iter", [](morphio::mut::Morphology* morph, morphio::IterType type) {
+        .def("iter", [](morphio::mut::Morphology* morph, IterType type) {
                 switch (type) {
-                case morphio::IterType::DEPTH_FIRST:
+                case IterType::DEPTH_FIRST:
                     return py::make_iterator(morph->depth_begin(), morph->depth_end());
-                case morphio::IterType::BREADTH_FIRST:
+                case IterType::BREADTH_FIRST:
                     return py::make_iterator(morph->breadth_begin(), morph->breadth_end());
-                case morphio::IterType::UPSTREAM:
+                case IterType::UPSTREAM:
                 default:
                 LBTHROW(morphio::MorphioError("Only iteration types depth_first and breadth_first are supported"));
                 }
@@ -104,7 +104,7 @@ static void bind_mutable_module(py::module &m) {
             "iter_type controls the order of iteration on sections of a given neurite. 2 values can be passed:\n"
             "- morphio.IterType.depth_first (default)\n"
             "- morphio.IterType.breadth_first",
-            "iter_type"_a=morphio::IterType::DEPTH_FIRST);
+            "iter_type"_a=IterType::DEPTH_FIRST);
 
 
     mutable_morphology.def("append_root_section", static_cast<std::shared_ptr<morphio::mut::Section> (morphio::mut::Morphology::*)
@@ -280,13 +280,13 @@ static void bind_mutable_module(py::module &m) {
         .def_property_readonly("children", &morphio::mut::Section::children,
              "Returns a list of children IDs")
         // Iterators
-        .def("iter", [](morphio::mut::Section* section, morphio::IterType type) {
+        .def("iter", [](morphio::mut::Section* section, IterType type) {
                          switch (type) {
-                         case morphio::IterType::DEPTH_FIRST:
+                         case IterType::DEPTH_FIRST:
                              return py::make_iterator(section->depth_begin(), section->depth_end());
-                         case morphio::IterType::BREADTH_FIRST:
+                         case IterType::BREADTH_FIRST:
                              return py::make_iterator(section->breadth_begin(), section->breadth_end());
-                         case morphio::IterType::UPSTREAM:
+                         case IterType::UPSTREAM:
                              return py::make_iterator(section->upstream_begin(), section->upstream_end());
                          default:
                              LBTHROW(morphio::MorphioError("Only iteration types depth_first, breadth_first and upstream are supported"));
@@ -299,7 +299,7 @@ static void bind_mutable_module(py::module &m) {
             "- morphio.IterType.depth_first (default)\n"
             "- morphio.IterType.breadth_first\n"
             "- morphio.IterType.upstream\n",
-            "iter_type"_a=morphio::IterType::DEPTH_FIRST)
+            "iter_type"_a=IterType::DEPTH_FIRST)
 
         // Editing
         .def("append_section", static_cast<std::shared_ptr<morphio::mut::Section> (morphio::mut::Section::*) (const morphio::Section&, bool)>(&morphio::mut::Section::appendSection),

--- a/binds/python/bind_mutable.cpp
+++ b/binds/python/bind_mutable.cpp
@@ -4,6 +4,8 @@
 #include <morphio/mut/section.h>
 #include <morphio/mut/soma.h>
 
+#include "bind_enums.h"
+
 namespace py = pybind11;
 
 static void bind_mutable_module(py::module &m) {

--- a/binds/python/bindings_utils.cpp
+++ b/binds/python/bindings_utils.cpp
@@ -4,13 +4,6 @@
 
 namespace py = pybind11;
 
-enum IterType
-{
-    DEPTH_FIRST,
-    BREADTH_FIRST,
-    UPSTREAM
-};
-
 static py::array_t<float> span_array_to_ndarray(const morphio::range<const std::array<float, 3> > &span)
 {
     const void* ptr = static_cast<const void*>(span.data());

--- a/binds/python/bindings_utils.cpp
+++ b/binds/python/bindings_utils.cpp
@@ -4,6 +4,12 @@
 
 namespace py = pybind11;
 
+enum IterType
+{
+    DEPTH_FIRST,
+    BREADTH_FIRST,
+    UPSTREAM
+};
 
 static py::array_t<float> span_array_to_ndarray(const morphio::range<const std::array<float, 3> > &span)
 {

--- a/binds/python/morphio.cpp
+++ b/binds/python/morphio.cpp
@@ -16,7 +16,6 @@
 #include <morphio/soma.h>
 #include <morphio/errorMessages.h>
 
-
 #include "bindings_utils.cpp"
 #include "bind_misc.cpp"
 #include "bind_immutable.cpp"
@@ -25,6 +24,7 @@
 
 namespace py = pybind11;
 using namespace py::literals;
+
 
 #pragma GCC diagnostic ignored "-Wmissing-prototypes"
 PYBIND11_MODULE(morphio, m) {

--- a/include/morphio/enums.h
+++ b/include/morphio/enums.h
@@ -87,13 +87,6 @@ inline std::ostream& operator<<(std::ostream& os, const MorphologyVersion v)
     }
 }
 
-enum IterType
-{
-    DEPTH_FIRST,
-    BREADTH_FIRST,
-    UPSTREAM
-};
-
 enum SomaType
 {
     SOMA_UNDEFINED = 0,

--- a/include/morphio/iterators.h
+++ b/include/morphio/iterators.h
@@ -19,9 +19,8 @@ class Iterator
 
     T container;
 
-    Iterator();
-
 public:
+    Iterator();
     Iterator(const Section& section);
     Iterator(const Morphology& morphology);
     bool operator==(Iterator other) const;

--- a/include/morphio/mut/iterators.h
+++ b/include/morphio/mut/iterators.h
@@ -17,9 +17,9 @@ class Iterator
     T container;
 
 public:
+    Iterator();
     Iterator(std::shared_ptr<Section> rootSection);
     Iterator(const Morphology& morphology);
-    Iterator();
     bool operator==(Iterator other) const;
     bool operator!=(Iterator other) const;
     std::shared_ptr<Section> operator*() const;


### PR DESCRIPTION
About iterator: Done so that the class can be derived.
Protected would work as well, but I don't think there is a good reason
for not exposing it.

About IterType: IterType is only used in the python bindings to expose the parameter of the function `Section.iter`