### PR TITLE
Add Section.__str__  in binding

### DIFF
--- a/binds/python/bind_immutable.cpp
+++ b/binds/python/bind_immutable.cpp
@@ -39,7 +39,6 @@ static void bind_immutable_module(py::module &m) {
 
         .def("as_mutable", [](const morphio::Morphology* morph) { return morphio::mut::Morphology(*morph); })
 
-
         // Cell sub-parts accessors
         .def_property_readonly("soma", &morphio::Morphology::soma,
                                "Returns the soma object")
@@ -151,6 +150,11 @@ static void bind_immutable_module(py::module &m) {
         .def("__ne__", [](const morphio::Section& a, const morphio::Section& b) {
                 return a.operator!=(b);
             }, py::is_operator())
+        .def("__str__", [](const morphio::Section& section) {
+                std::stringstream ss;
+                ss << section;
+                return ss.str();
+            })
 
         // Topology-related member functions
         .def_property_readonly("parent", &morphio::Section::parent,

--- a/binds/python/bind_mutable.cpp
+++ b/binds/python/bind_mutable.cpp
@@ -230,6 +230,12 @@ static void bind_mutable_module(py::module &m) {
         .def("__ne__", [](const morphio::mut::Section& a, const morphio::mut::Section& b) {
                 return a.operator!=(b);
                 }, py::is_operator())
+        .def("__str__", [](const morphio::mut::Section& section) {
+                std::stringstream ss;
+                // morphio::operator<<(ss, const morphio::mut::Section&);
+                ss << section;
+                return ss.str();
+            })
 
         .def_property_readonly("id", &morphio::mut::Section::id,
                                "Return the section ID")

--- a/binds/python/bind_mutable.cpp
+++ b/binds/python/bind_mutable.cpp
@@ -232,7 +232,6 @@ static void bind_mutable_module(py::module &m) {
                 }, py::is_operator())
         .def("__str__", [](const morphio::mut::Section& section) {
                 std::stringstream ss;
-                // morphio::operator<<(ss, const morphio::mut::Section&);
                 ss << section;
                 return ss.str();
             })

--- a/include/morphio/mut/section.h
+++ b/include/morphio/mut/section.h
@@ -125,7 +125,6 @@ private:
 
 void friendDtorForSharedPtr(Section* section);
 
-std::ostream& operator<<(std::ostream&, const Section&);
 std::ostream& operator<<(std::ostream&, std::shared_ptr<Section>);
 
 } // namespace mut

--- a/tests/test_4_immut.py
+++ b/tests/test_4_immut.py
@@ -147,3 +147,7 @@ def test_iterators_vasculature():
     for sec in morphology.iter():
         all_sections.remove(sec.id)
     assert_equal(len(all_sections), 0)
+
+def test_section___str__():
+    assert_equal(str(CELLS['asc'].root_sections[0]),
+                 'Section(id=0, points=[(0 0 0),..., (0 5 0)])')

--- a/tests/test_5_mut.py
+++ b/tests/test_5_mut.py
@@ -448,3 +448,7 @@ def test_annotation():
     assert_equal(len(n.annotations), 1)
     annotation = n.annotations[0]
     assert_equal(annotation.type, morphio.AnnotationType.single_child)
+
+def test_section___str__():
+    assert_equal(str(SIMPLE.root_sections[0]),
+                 'Section(id=0, points=[(0 0 0),..., (0 5 0)])')


### PR DESCRIPTION
So that `print(section)` prints something more meaningful than the memory address.