### PR TITLE
Fix case where SWC has a bifurcation at root point

### DIFF
--- a/src/plugin/morphologySWC.cpp
+++ b/src/plugin/morphologySWC.cpp
@@ -340,7 +340,7 @@ public:
                 properties._diameters.push_back(samples[parentId].diameter);
             }
 
-            // Handle the case, bifurctation at root point
+            // Handle the case, bifurcatation at root point
             if (isRootPoint(samples[parentId]))
                 section = morph.appendRootSection(properties, sample.type);
             else

--- a/tests/data/neurite_wrong_root_point.swc
+++ b/tests/data/neurite_wrong_root_point.swc
@@ -4,3 +4,4 @@
  4 3 0    0      0     10   3 # <-- should have parent ID: 1
  5 3 0    0      1     10   4
  6 3 0    0      1     10   3 # <-- should have parent ID: 1
+ 7 3 0    0      2     10   6

--- a/tests/data/reversed_NRN_neurite_order.swc
+++ b/tests/data/reversed_NRN_neurite_order.swc
@@ -2,5 +2,8 @@
 # In this file the order is reversed
  1 1  0  0 0 1. -1
  2 4  1  1 1 1.  1 # apical
- 3 3  2  2 2 1.  1 # basal
- 4 2  3  3 3 1.  1 # axon
+ 3 4  2  1 1 1.  2
+ 4 3  0  1 2 1.  1 # basal
+ 5 3  0  1 3 1.  4
+ 6 2  3  3 3 1.  1 # axon
+ 7 2  3  3 4 1.  6

--- a/tests/test_1_swc.py
+++ b/tests/test_1_swc.py
@@ -407,6 +407,40 @@ def test_unsupported_section_type():
         'Unsupported section type: 5',
         strip_color_codes(str(obj.exception)))
 
+def test_root_node_split():
+    '''Test that a bifurcation at the root point produces
+    two root sections
+    '''
+    # with tmp_swc_file('''1	1	0 0 0 1	-1
+    #                      2	3	1 0 0 1  1
+    #                      3	3	1 1 0 1  2
+    #                      4	3	1 0 1 1  2
+    #                      ''') as tmp_file:
+    #     n = Morphology(tmp_file.name)
+    #     assert_equal(len(n.root_sections), 2)
+    #     assert_array_equal(n.root_sections[0].points,
+    #                        [[1, 0, 0], [1, 1, 0]])
+    #     assert_array_equal(n.root_sections[1].points,
+    #                        [[1, 0, 0], [1, 0, 1]])
+
+    # Normal bifurcation
+    with tmp_swc_file('''1	1	0 0 0 1	-1
+                         2	3	1 0 0 1  1
+                         3	3	2 1 0 1  2
+                         4	3	1 1 0 1  3
+                         5	3	1 0 1 1  3
+                         ''') as tmp_file:
+        n = Morphology(tmp_file.name)
+        assert_equal(len(n.root_sections), 1)
+        root = n.root_sections[0]
+        assert_array_equal(root.points,
+                           [[1, 0, 0], [2, 1, 0]])
+        assert_equal(len(root.children), 2)
+        assert_array_equal(root.children[0].points,
+                           [[2, 1, 0], [1, 1, 0]])
+        assert_array_equal(root.children[1].points,
+                           [[2, 1, 0], [1, 0, 1]])
+
 
 def test_three_point_soma():
     n = Morphology(os.path.join(_path, 'three_point_soma.swc'))

--- a/tests/test_1_swc.py
+++ b/tests/test_1_swc.py
@@ -411,17 +411,17 @@ def test_root_node_split():
     '''Test that a bifurcation at the root point produces
     two root sections
     '''
-    # with tmp_swc_file('''1	1	0 0 0 1	-1
-    #                      2	3	1 0 0 1  1
-    #                      3	3	1 1 0 1  2
-    #                      4	3	1 0 1 1  2
-    #                      ''') as tmp_file:
-    #     n = Morphology(tmp_file.name)
-    #     assert_equal(len(n.root_sections), 2)
-    #     assert_array_equal(n.root_sections[0].points,
-    #                        [[1, 0, 0], [1, 1, 0]])
-    #     assert_array_equal(n.root_sections[1].points,
-    #                        [[1, 0, 0], [1, 0, 1]])
+    with tmp_swc_file('''1	1	0 0 0 1	-1
+                         2	3	1 0 0 1  1
+                         3	3	1 1 0 1  2
+                         4	3	1 0 1 1  2
+                         ''') as tmp_file:
+        n = Morphology(tmp_file.name)
+        assert_equal(len(n.root_sections), 2)
+        assert_array_equal(n.root_sections[0].points,
+                           [[1, 0, 0], [1, 1, 0]])
+        assert_array_equal(n.root_sections[1].points,
+                           [[1, 0, 0], [1, 0, 1]])
 
     # Normal bifurcation
     with tmp_swc_file('''1	1	0 0 0 1	-1


### PR DESCRIPTION
When there was a bifurcation at root point, one neurite would go missing