### PR TITLE
small shell script cleanups for wheelbuilding

### DIFF
--- a/packaging/python_wheel/build_docker_image.sh
+++ b/packaging/python_wheel/build_docker_image.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-set -o xtrace
+set -euxo pipefail
+
 BASE=$(git rev-parse --show-toplevel)
 
 if [ "$(docker images | grep morphio_wheel | wc -l)" != "0" ]; then
@@ -7,11 +8,19 @@ if [ "$(docker images | grep morphio_wheel | wc -l)" != "0" ]; then
 
 else
     echo "docker image morphio_wheel not found, building it..."
-    docker build -t bluebrain/morphio_wheel \
-           --build-arg http_proxy=${HTTP_PROXY-$http_proxy} \
-           --build-arg https_proxy=${HTTPS_PROXY-$https_proxy} \
-           $BASE/packaging/python_wheel | tee build.log
+    DOCKER_ENV=
+    if [[ -v JENKINS_URL ]]; then
+       DOCKER_ENV="--build-arg http_proxy=${HTTP_PROXY-$http_proxy}"
+       DOCKER_ENV+="--build-arg https_proxy=${HTTPS_PROXY-$https_proxy}"
+    fi
 
-    ID=$(tail -1 build.log | awk '{print $3;}')
-    upload2repo -t docker -i $ID -g latest -n morphio_wheel
+    docker build -t bluebrain/morphio_wheel                     \
+           $DOCKER_ENV                                          \
+           $BASE/packaging/python_wheel                         \
+           | tee build.log
+
+    if [[ -v JENKINS_URL ]]; then
+        ID=$(tail -1 build.log | awk '{print $3;}')
+        upload2repo -t docker -i $ID -g latest -n morphio_wheel
+    fi
 fi

--- a/packaging/python_wheel/build_wheel.sh
+++ b/packaging/python_wheel/build_wheel.sh
@@ -1,40 +1,33 @@
 #!/usr/bin/env bash
-# set -e
-set -o xtrace
+set -euxo pipefail
 
-export MORPHIO_BASE=$(readlink -f "$( cd "$(dirname "$0")" ; pwd -P )"/../..)
-export WHEELHOUSE=${MORPHIO_BASE}/packaging/python_wheel/wheelhouse/
+MORPHIO_BASE=$(git rev-parse --show-toplevel)
+WHEELHOUSE=$MORPHIO_BASE/packaging/python_wheel/wheelhouse/
 
-if [ "$(uname)" == "Darwin" ]; then
-    export PYTHON_VERSIONS="cp27-cp27m"
-    export AUDIT_CMD="delocate-wheel -w $WHEELHOUSE"
+UNAME=$(uname)
+if [[ $UNAME == Darwin ]]; then
+    PYTHON_VERSIONS="cp27-cp27m"
+    AUDIT_CMD="delocate-wheel -w $WHEELHOUSE"
 else
-    export AUDIT_CMD="auditwheel repair -w $WHEELHOUSE"
-    # cp35-cp35m is ignored while https://github.com/pybind/pybind11/issues/314
-    # is not solved
-    export PYTHON_VERSIONS="cp36-cp36m cp27-cp27mu cp27-cp27m"
+    PYTHON_VERSIONS="cp27-cp27mu cp27-cp27m cp35-cp35m cp36-cp36m cp37-cp37m"
+    AUDIT_CMD="auditwheel repair -w $WHEELHOUSE"
 fi
 
-rm -rf ${MORPHIO_BASE}/envs/
 build_morphio()
 {
-    if [ "$(uname)" == "Darwin" ]; then
+    local version=$1
+    if [[ $UNAME == Darwin ]]; then
         local PYTHON=$(which python)
     else
         # in manylinux1 docker image
         local PYTHON=/opt/python/$version/bin/python
     fi
 
-    cd ${MORPHIO_BASE}
-    rm -rf build dist morphio.egg-info bin
-
+    cd "$MORPHIO_BASE"
     $PYTHON setup.py bdist_wheel
-    # "${PYBIN}/pip" wheel ${MORPHIO_BASE} -w ${WHEELHOUSE}
-    ${AUDIT_CMD} ${MORPHIO_BASE}/dist/*${version}*
-    rm -rf build dist morphio.egg-info bin
+    $AUDIT_CMD $MORPHIO_BASE/dist/*${version}*
+    rm -rf build dist morphio.egg-info
 }
-
-rm -rf ${MORPHIO_BASE}/bin
 
 for version in $PYTHON_VERSIONS; do
     build_morphio $version

--- a/packaging/python_wheel/build_wheel_in_manylinux1_docker.sh
+++ b/packaging/python_wheel/build_wheel_in_manylinux1_docker.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-set -o xtrace
 BASE=$(git rev-parse --show-toplevel)
 
-export PIPPROXY="-i https://bbpteam.epfl.ch/repository/devpi/simple"
-export http_proxy=${HTTP_PROXY-$http_proxy}
-export https_proxy=${HTTPS_PROXY-$https_proxy}
+PIPPROXY="-i https://bbpteam.epfl.ch/repository/devpi/simple"
+http_proxy=${HTTP_PROXY-$http_proxy}
+https_proxy=${HTTPS_PROXY-$https_proxy}
 
 docker images
 docker run  \


### PR DESCRIPTION
* enable python 3.5
* turn on more error handling (set -euxo pipefail)
* allow for building the docker image locally, without it trying to push it as if it were run in Jenkins
* export fewer environment variables