### PR TITLE
Add Morphology::sectionOffsets, the list of section offsets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
       env:
         CXX: clang++
         CC: clang
+
     - os: osx
       osx_image: xcode10.1
       language: generic
@@ -19,13 +20,13 @@ matrix:
       env:
         CXX: clang++
         CC: clang
-     - os: osx
-       osx_image: xcode10.1
-       language: generic
-       python: 2.7
-       env:
-         CXX: g++
-         CC: gcc
+    - os: osx
+      osx_image: xcode10.1
+      language: generic
+      python: 2.7
+      env:
+        CXX: g++
+        CC: gcc
 
 cache:
   directories:

--- a/binds/python/bind_immutable.cpp
+++ b/binds/python/bind_immutable.cpp
@@ -52,23 +52,37 @@ static void bind_immutable_module(py::module &m) {
         .def_property_readonly("points", [](morphio::Morphology* morpho){
                 return py::array(static_cast<py::ssize_t>(morpho->points().size()), morpho->points().data());
             },
-            "Returns a list with all points from all sections")
-        .def_property_readonly("section_offsets", [](morphio::Morphology* morpho){
-                return py::array(static_cast<py::ssize_t>(morpho->sectionOffsets().size()), morpho->sectionOffsets().data());
-            },
-            "Returns a list with offsets to access data of a specific section in the points and diameters arrays")
-        .def_property_readonly("diameters", [](morphio::Morphology* morpho){
-                auto diameters = morpho->diameters();
+            "Returns a list with all points from all sections (soma points are not included)\n"
+            "Note: points belonging to the n'th section are located at indices:\n"
+            "[Morphology.sectionOffsets(n), Morphology.sectionOffsets(n+1)[")
+        .def_property_readonly("diameters", [](const morphio::Morphology& morpho){
+                auto diameters = morpho.diameters();
                 return py::array(static_cast<py::ssize_t>(diameters.size()), diameters.data());
             },
-            "Returns a list with all diameters from all sections (soma points are not included)")
-        .def_property_readonly("perimeters", [](morphio::Morphology* obj){
-                auto data = obj->perimeters();
+            "Returns a list with all diameters from all sections (soma points are not included)\n"
+            "Note: diameters belonging to the n'th section are located at indices:\n"
+            "[Morphology.sectionOffsets(n), Morphology.sectionOffsets(n+1)[")
+        .def_property_readonly("perimeters", [](const morphio::Morphology& obj){
+                auto data = obj.perimeters();
                 return py::array(static_cast<py::ssize_t>(data.size()), data.data());
             },
-            "Returns a list with all perimeters from all sections")
-        .def_property_readonly("section_types", [](morphio::Morphology* obj){
-                auto data = obj->sectionTypes();
+            "Returns a list with all perimeters from all sections (soma points are not included)\n"
+            "Note: perimeters belonging to the n'th section are located at indices:\n"
+            "[Morphology.sectionOffsets(n), Morphology.sectionOffsets(n+1)[")
+        .def_property_readonly("section_offsets", [](const morphio::Morphology& morpho){
+                return py::array(static_cast<py::ssize_t>(morpho.sectionOffsets().size()),
+                                 morpho.sectionOffsets().data());
+            },
+            "Returns a list with offsets to access data of a specific section in the points\n"
+            "and diameters arrays.\n"
+            "\n"
+            "Example: accessing diameters of n'th section will be located in the DIAMETERS\n"
+            "array from DIAMETERS[sectionOffsets(n)] to DIAMETERS[sectionOffsets(n+1)-1]\n"
+            "\n"
+            "Note: for convenience, the last point of this array is the points array size\n"
+            "so that the above example works also for the last section.")
+        .def_property_readonly("section_types", [](const morphio::Morphology& morph){
+                auto data = morph.sectionTypes();
                 return py::array(static_cast<py::ssize_t>(data.size()), data.data());
             },
             "Returns a vector with the section type of every section")

--- a/binds/python/bind_immutable.cpp
+++ b/binds/python/bind_immutable.cpp
@@ -50,20 +50,21 @@ static void bind_immutable_module(py::module &m) {
 
         // Property accessors
         .def_property_readonly("points", [](morphio::Morphology* morpho){
-                return py::array(static_cast<py::ssize_t>(morpho->points().size()), morpho->points().data());
+                const auto& data = morpho->points();
+                return py::array(static_cast<py::ssize_t>(data.size()), data.data());
             },
             "Returns a list with all points from all sections (soma points are not included)\n"
             "Note: points belonging to the n'th section are located at indices:\n"
             "[Morphology.sectionOffsets(n), Morphology.sectionOffsets(n+1)[")
         .def_property_readonly("diameters", [](const morphio::Morphology& morpho){
-                auto diameters = morpho.diameters();
-                return py::array(static_cast<py::ssize_t>(diameters.size()), diameters.data());
+                const auto& data = morpho.diameters();
+                return py::array(static_cast<py::ssize_t>(data.size()), data.data());
             },
             "Returns a list with all diameters from all sections (soma points are not included)\n"
             "Note: diameters belonging to the n'th section are located at indices:\n"
             "[Morphology.sectionOffsets(n), Morphology.sectionOffsets(n+1)[")
         .def_property_readonly("perimeters", [](const morphio::Morphology& obj){
-                auto data = obj.perimeters();
+                const auto& data = obj.perimeters();
                 return py::array(static_cast<py::ssize_t>(data.size()), data.data());
             },
             "Returns a list with all perimeters from all sections (soma points are not included)\n"
@@ -81,7 +82,7 @@ static void bind_immutable_module(py::module &m) {
             "Note: for convenience, the last point of this array is the points array size\n"
             "so that the above example works also for the last section.")
         .def_property_readonly("section_types", [](const morphio::Morphology& morph){
-                auto data = morph.sectionTypes();
+                const auto& data = morph.sectionTypes();
                 return py::array(static_cast<py::ssize_t>(data.size()), data.data());
             },
             "Returns a vector with the section type of every section")

--- a/binds/python/bind_immutable.cpp
+++ b/binds/python/bind_immutable.cpp
@@ -70,8 +70,7 @@ static void bind_immutable_module(py::module &m) {
             "Note: perimeters belonging to the n'th section are located at indices:\n"
             "[Morphology.sectionOffsets(n), Morphology.sectionOffsets(n+1)[")
         .def_property_readonly("section_offsets", [](const morphio::Morphology& morpho){
-                return py::array(static_cast<py::ssize_t>(morpho.sectionOffsets().size()),
-                                 morpho.sectionOffsets().data());
+                return as_pyarray(morpho.sectionOffsets());
             },
             "Returns a list with offsets to access data of a specific section in the points\n"
             "and diameters arrays.\n"

--- a/binds/python/bind_immutable.cpp
+++ b/binds/python/bind_immutable.cpp
@@ -53,6 +53,10 @@ static void bind_immutable_module(py::module &m) {
                 return py::array(static_cast<py::ssize_t>(morpho->points().size()), morpho->points().data());
             },
             "Returns a list with all points from all sections")
+        .def_property_readonly("section_offsets", [](morphio::Morphology* morpho){
+                return py::array(static_cast<py::ssize_t>(morpho->sectionOffsets().size()), morpho->sectionOffsets().data());
+            },
+            "Returns a list with offsets to access data of a specific section in the points and diameters arrays")
         .def_property_readonly("diameters", [](morphio::Morphology* morpho){
                 auto diameters = morpho->diameters();
                 return py::array(static_cast<py::ssize_t>(diameters.size()), diameters.data());

--- a/binds/python/bindings_utils.cpp
+++ b/binds/python/bindings_utils.cpp
@@ -1,4 +1,7 @@
+#include <utility>
+
 #include <pybind11/pybind11.h>
+
 #include <morphio/types.h>
 #include <morphio/enums.h>
 

--- a/binds/python/bindings_utils.cpp
+++ b/binds/python/bindings_utils.cpp
@@ -65,3 +65,24 @@ static morphio::Points array_to_points(py::array_t<float> &buf){
     }
     return points;
 }
+
+/**
+ * @brief "Casts" a Cpp sequence to a python array (no memory copies)
+ *  Python capsule handles void pointers to objects and makes sure
+ *      that they will remain alive.
+ *
+ *      https://github.com/pybind/pybind11/issues/1042#issuecomment-325941022
+ */
+template <typename Sequence>
+inline py::array_t<typename Sequence::value_type> as_pyarray(Sequence&& seq) {
+    // Move entire object to heap. Memory handled via Python capsule
+    Sequence* seq_ptr = new Sequence(std::move(seq));
+    // Capsule shall delete sequence object when done
+    auto capsule = py::capsule(seq_ptr,
+                               [](void* p) { delete reinterpret_cast<Sequence*>(p); });
+
+    return py::array(static_cast<py::ssize_t>(seq_ptr->size()),  // shape of array
+                     seq_ptr->data(),  // c-style contiguous strides for Sequence
+                     capsule           // numpy array references this parent
+    );
+}

--- a/include/morphio/morphology.h
+++ b/include/morphio/morphology.h
@@ -83,6 +83,12 @@ public:
     const Points& points() const;
 
     /**
+     * Returns a list with offsets to access data of a specific section in the points
+     * and diameters arrays
+     **/
+    const std::vector<int> sectionOffsets() const;
+
+    /**
      * Return a vector with all diameters from all sections
      * (soma points are not included)
      **/

--- a/include/morphio/morphology.h
+++ b/include/morphio/morphology.h
@@ -86,7 +86,7 @@ public:
      * Returns a list with offsets to access data of a specific section in the points
      * and diameters arrays
      **/
-    const std::vector<int> sectionOffsets() const;
+    const std::vector<uint32_t> sectionOffsets() const;
 
     /**
      * Return a vector with all diameters from all sections

--- a/include/morphio/morphology.h
+++ b/include/morphio/morphology.h
@@ -46,35 +46,35 @@ public:
     /**
      * Return the soma object
      **/
-    const Soma soma() const;
+    Soma soma() const;
 
     /**
      * Return the mitochondria object
      **/
-    const Mitochondria mitochondria() const;
+    Mitochondria mitochondria() const;
 
     /**
      * Return the annotation object
      **/
-    const std::vector<Property::Annotation> annotations() const;
+    const std::vector<Property::Annotation>& annotations() const;
 
     /**
      * Return a vector of all root sections
      * (sections whose parent ID are -1)
      **/
-    const std::vector<Section> rootSections() const;
+    std::vector<Section> rootSections() const;
 
     /**
      * Return a vector containing all section objects.
      **/
-    const std::vector<Section> sections() const;
+    std::vector<Section> sections() const;
 
     /**
      * Return the Section with the given id.
      *
      * @throw RawDataError if the id is out of range
      */
-    const Section section(const uint32_t& id) const;
+    Section section(const uint32_t& id) const;
 
     /**
      * Return a vector with all points from all sections

--- a/include/morphio/morphology.h
+++ b/include/morphio/morphology.h
@@ -84,7 +84,13 @@ public:
 
     /**
      * Returns a list with offsets to access data of a specific section in the points
-     * and diameters arrays
+     * and diameters arrays.
+     *
+     * Example: accessing diameters of n'th section will be located in the DIAMETERS
+     * array from DIAMETERS[sectionOffsets(n)] to DIAMETERS[sectionOffsets(n+1)-1]
+     *
+     * Note: for convenience, the last point of this array is the points() array size
+     * so that the above example works also for the last section.
      **/
     const std::vector<uint32_t> sectionOffsets() const;
 

--- a/include/morphio/morphology.h
+++ b/include/morphio/morphology.h
@@ -92,7 +92,7 @@ public:
      * Note: for convenience, the last point of this array is the points() array size
      * so that the above example works also for the last section.
      **/
-    const std::vector<uint32_t> sectionOffsets() const;
+    std::vector<uint32_t> sectionOffsets() const;
 
     /**
      * Return a vector with all diameters from all sections

--- a/include/morphio/section.h
+++ b/include/morphio/section.h
@@ -83,7 +83,7 @@ public:
      */
     SectionType type() const;
     friend class mut::Section;
-    friend const Section Morphology::section(const uint32_t&) const;
+    friend Section Morphology::section(const uint32_t&) const;
     friend class SectionBase<Section>;
 
 protected:

--- a/src/morphology.cpp
+++ b/src/morphology.cpp
@@ -140,10 +140,12 @@ const Points& Morphology::points() const
 
 const std::vector<uint32_t> Morphology::sectionOffsets() const
 {
-    const std::vector<std::array<int, 2>>& indices_and_parents = get<Property::Section>();
-    std::vector<uint32_t> indices(indices_and_parents.size());
+    const std::vector<Property::Section::Type>& indices_and_parents = get<Property::Section>();
+    auto size = indices_and_parents.size();
+    std::vector<uint32_t> indices(size+1);
     std::transform(indices_and_parents.begin(), indices_and_parents.end(), indices.begin(),
-                   [](const std::array<int, 2>& pair) { return pair[0]; });
+                   [](const Property::Section::Type& pair) { return pair[0]; });
+    indices[size] = points().size();
     return indices;
 }
 

--- a/src/morphology.cpp
+++ b/src/morphology.cpp
@@ -137,14 +137,26 @@ const Points& Morphology::points() const
 {
     return get<Property::Point>();
 }
+
+const std::vector<int> Morphology::sectionOffsets() const
+{
+    const std::vector<std::array<int, 2>>& indices_and_parents = get<Property::Section>();
+    std::vector<int> indices(indices_and_parents.size());
+    std::transform(indices_and_parents.begin(), indices_and_parents.end(), indices.begin(),
+                   [](const std::array<int, 2>& pair) { return pair[0]; });
+    return indices;
+}
+
 const std::vector<float>& Morphology::diameters() const
 {
     return get<Property::Diameter>();
 }
+
 const std::vector<float>& Morphology::perimeters() const
 {
     return get<Property::Perimeter>();
 }
+
 const std::vector<SectionType>& Morphology::sectionTypes() const
 {
     return get<Property::SectionType>();

--- a/src/morphology.cpp
+++ b/src/morphology.cpp
@@ -145,7 +145,7 @@ const std::vector<uint32_t> Morphology::sectionOffsets() const
     std::vector<uint32_t> indices(size+1);
     std::transform(indices_and_parents.begin(), indices_and_parents.end(), indices.begin(),
                    [](const Property::Section::Type& pair) { return pair[0]; });
-    indices[size] = points().size();
+    indices[size] = static_cast<uint32_t>(points().size());
     return indices;
 }
 

--- a/src/morphology.cpp
+++ b/src/morphology.cpp
@@ -79,27 +79,27 @@ Morphology::~Morphology()
 {
 }
 
-const Soma Morphology::soma() const
+Soma Morphology::soma() const
 {
-    return Soma(_properties);
+    return {_properties};
 }
 
-const Mitochondria Morphology::mitochondria() const
+Mitochondria Morphology::mitochondria() const
 {
-    return Mitochondria(_properties);
+    return {_properties};
 }
 
-const std::vector<Property::Annotation> Morphology::annotations() const
+const std::vector<Property::Annotation>& Morphology::annotations() const
 {
     return _properties->_annotations;
 }
 
-const Section Morphology::section(const uint32_t& id) const
+Section Morphology::section(const uint32_t& id) const
 {
-    return Section(id, _properties);
+    return {id, _properties};
 }
 
-const std::vector<Section> Morphology::rootSections() const
+std::vector<Section> Morphology::rootSections() const
 {
     std::vector<Section> result;
     try {
@@ -115,7 +115,7 @@ const std::vector<Section> Morphology::rootSections() const
     }
 }
 
-const std::vector<Section> Morphology::sections() const
+std::vector<Section> Morphology::sections() const
 {
     // TODO: Make this more performant when needed
     std::vector<Section> sections_;

--- a/src/morphology.cpp
+++ b/src/morphology.cpp
@@ -138,7 +138,7 @@ const Points& Morphology::points() const
     return get<Property::Point>();
 }
 
-const std::vector<uint32_t> Morphology::sectionOffsets() const
+std::vector<uint32_t> Morphology::sectionOffsets() const
 {
     const std::vector<Property::Section::Type>& indices_and_parents = get<Property::Section>();
     auto size = indices_and_parents.size();

--- a/src/morphology.cpp
+++ b/src/morphology.cpp
@@ -138,10 +138,10 @@ const Points& Morphology::points() const
     return get<Property::Point>();
 }
 
-const std::vector<int> Morphology::sectionOffsets() const
+const std::vector<uint32_t> Morphology::sectionOffsets() const
 {
     const std::vector<std::array<int, 2>>& indices_and_parents = get<Property::Section>();
-    std::vector<int> indices(indices_and_parents.size());
+    std::vector<uint32_t> indices(indices_and_parents.size());
     std::transform(indices_and_parents.begin(), indices_and_parents.end(), indices.begin(),
                    [](const std::array<int, 2>& pair) { return pair[0]; });
     return indices;

--- a/tests/test_0_API.py
+++ b/tests/test_0_API.py
@@ -27,7 +27,7 @@ def test_mut_immut_have_same_methods():
     def methods(cls):
         return set(method for method in dir(cls) if not method[:2] == '__')
 
-    only_in_immut = {'section_types', 'diameters', 'perimeters', 'points', 'as_mutable'}
+    only_in_immut = {'section_types', 'diameters', 'perimeters', 'points', 'section_offsets', 'as_mutable'}
     only_in_mut = {'write', 'append_root_section', 'delete_section', 'build_read_only', 'as_immutable'}
     assert_equal(methods(morphio.Morphology) - only_in_immut,
                  methods(morphio.mut.Morphology) - only_in_mut)

--- a/tests/test_1_swc.py
+++ b/tests/test_1_swc.py
@@ -34,6 +34,7 @@ def test_read_single_neurite():
                                  [0, 0, 3],
                                  [0, 0, 4],
                                  [0, 0, 5]]))
+    assert_array_equal(n.section_offsets, [0])
 
 
 def test_skip_comments():
@@ -72,8 +73,8 @@ def test_read_simple():
     assert_equal(len(simple.root_sections[0].children), 2)
     assert_equal(simple.root_sections[0].children[0].id, 1)
     assert_equal(simple.root_sections[0].children[1].id, 2)
-    # assert_array_equal(simple.root_sections[0].children[0].points, [[0, 5, 0], [-5, 5, 0]])
-    # assert_array_equal(simple.root_sections[1].points, [[0, 0, 0], [0, -4, 0]])
+    assert_array_equal(simple.root_sections[0].children[0].points, [[0, 5, 0], [-5, 5, 0]])
+    assert_array_equal(simple.root_sections[1].points, [[0, 0, 0], [0, -4, 0]])
 
 
 def test_repeated_id():

--- a/tests/test_1_swc.py
+++ b/tests/test_1_swc.py
@@ -34,7 +34,7 @@ def test_read_single_neurite():
                                  [0, 0, 3],
                                  [0, 0, 4],
                                  [0, 0, 5]]))
-    assert_array_equal(n.section_offsets, [0])
+    assert_array_equal(n.section_offsets, [0, 4])
 
 
 def test_skip_comments():

--- a/tests/test_2_neurolucida.py
+++ b/tests/test_2_neurolucida.py
@@ -429,7 +429,6 @@ def test_spine():
                                  [13.75,    -5.96,   150.00]], dtype=np.float32))
 
 
-
 def test_markers():
     '''Test that markers do not prevent file from being read correctly'''
 

--- a/tests/test_4_immut.py
+++ b/tests/test_4_immut.py
@@ -50,10 +50,14 @@ def test_iter():
                            [0, 1, 2, 3, 4, 5])
         assert_array_equal([section.points for section in
                             cell.root_sections[0].children[0].iter(upstream)],
-                           [[[0.,  5.,  0.],
-                             [-5.,  5.,  0.]],
+                           [[[0., 5., 0.],
+                             [-5., 5., 0.]],
                             [[0., 0., 0.],
                              [0., 5., 0.]]])
+
+def test_section_offsets():
+    for _, cell in CELLS.items():
+        assert_array_equal(cell.section_offsets, [0, 2, 4, 6, 8, 10])
 
 
 def test_mitochondria():

--- a/tests/test_4_immut.py
+++ b/tests/test_4_immut.py
@@ -56,7 +56,7 @@ def test_iter():
                              [0., 5., 0.]]])
 
 def test_section_offsets():
-    for _, cell in CELLS.items():
+    for cell in CELLS.values():
         assert_array_equal(cell.section_offsets, [0, 2, 4, 6, 8, 10])
 
 

--- a/tests/test_4_immut.py
+++ b/tests/test_4_immut.py
@@ -56,8 +56,8 @@ def test_iter():
                              [0., 5., 0.]]])
 
 def test_section_offsets():
-    for cell in CELLS.values():
-        assert_array_equal(cell.section_offsets, [0, 2, 4, 6, 8, 10])
+    for cell in CELLS:
+        assert_array_equal(CELLS[cell].section_offsets, [0, 2, 4, 6, 8, 10, 12])
 
 
 def test_mitochondria():


### PR DESCRIPTION
In the immutable version, Morphology::points() and Morphology::diameters()
return a list of all points/diameters of the morphology. However it was no very
usable as the information about which point is in which section was not
available. See: https://github.com/BlueBrain/MorphIO/issues/116

This commits adds the method Morphology::sectionOffsets that returns the list
of offset to access the points of a given section.