### PR TITLE
Naive moving over

### DIFF
--- a/binds/python/bind_mutable.cpp
+++ b/binds/python/bind_mutable.cpp
@@ -27,7 +27,7 @@ static void bind_mutable_module(py::module &m) {
                                "Returns a list of all root sections IDs "
                                "(sections whose parent ID are -1)", py::return_value_policy::reference)
         .def_property_readonly("soma",
-                               static_cast<std::shared_ptr<morphio::mut::Soma>(morphio::mut::Morphology::*)()>(&morphio::mut::Morphology::soma),
+                               static_cast<std::shared_ptr<morphio::mut::Soma>&(morphio::mut::Morphology::*)()>(&morphio::mut::Morphology::soma),
                                "Returns a reference to the soma object\n\n"
                                "Note: multiple morphologies can share the same Soma instance")
         .def_property_readonly("mitochondria", static_cast<morphio::mut::Mitochondria& (morphio::mut::Morphology::*) ()>(&morphio::mut::Morphology::mitochondria),
@@ -92,7 +92,7 @@ static void bind_mutable_module(py::module &m) {
 
 
     mutable_morphology.def("append_root_section", static_cast<std::shared_ptr<morphio::mut::Section> (morphio::mut::Morphology::*)
-                           (std::shared_ptr<morphio::mut::Section>, bool)>(
+                           (const std::shared_ptr<morphio::mut::Section>&, bool)>(
                                &morphio::mut::Morphology::appendRootSection),
                            "Append the existing mutable Section as a root section\n"
                            "If recursive == true, all descendent will be appended as well",
@@ -128,7 +128,7 @@ static void bind_mutable_module(py::module &m) {
              "Append a new root MitoSection (if recursive == true, all descendent will be appended as well)",
              "immutable_section"_a, "recursive"_a = true)
         .def("append_root_section", static_cast<std::shared_ptr<morphio::mut::MitoSection> (morphio::mut::Mitochondria::*)
-             (const std::shared_ptr<morphio::mut::MitoSection>, bool recursive)>
+             (const std::shared_ptr<morphio::mut::MitoSection>&, bool recursive)>
              (&morphio::mut::Mitochondria::appendRootSection),
              "Append a new root MitoSection (if recursive == true, all descendent will be appended as well)",
              "section"_a, "recursive"_a = true)
@@ -197,7 +197,7 @@ static void bind_mutable_module(py::module &m) {
              "Append a new MitoSection to this mito section",
              "point_level_properties"_a)
 
-        .def("append_section", static_cast<std::shared_ptr<morphio::mut::MitoSection> (morphio::mut::MitoSection::*) (std::shared_ptr<morphio::mut::MitoSection>, bool)>(&morphio::mut::MitoSection::appendSection),
+        .def("append_section", static_cast<std::shared_ptr<morphio::mut::MitoSection> (morphio::mut::MitoSection::*) (const std::shared_ptr<morphio::mut::MitoSection>&, bool)>(&morphio::mut::MitoSection::appendSection),
              "Append a copy of the section to this section\n"
              "If recursive == true, all descendent will be appended as well",
              "section"_a, "recursive"_a=false)

--- a/binds/python/bind_mutable.cpp
+++ b/binds/python/bind_mutable.cpp
@@ -163,49 +163,51 @@ static void bind_mutable_module(py::module &m) {
             "section_id"_a=-1);
 
 
+    using mitosection_floats_f = std::vector<float>& (morphio::mut::MitoSection::*)();
+    using mitosection_ints_f = std::vector<uint32_t>& (morphio::mut::MitoSection::*)();
 
     // py::nodelete needed because morphio::mut::MitoSection has a private destructor
     // http://pybind11.readthedocs.io/en/stable/advanced/classes.html?highlight=private%20destructor#non-public-destructors
     py::class_<morphio::mut::MitoSection, std::shared_ptr<morphio::mut::MitoSection>>(m, "MitoSection")
         .def_property_readonly("id", &morphio::mut::MitoSection::id,
-                               "Return the section ID")
+            "Return the section ID")
         .def_property("diameters",
-                      &morphio::mut::MitoSection::diameters,
-                      [](morphio::mut::MitoSection* section,
-                         const std::vector<float>& _diameters) {
-                          section -> diameters() = _diameters;
-                      },
-                      "Returns the diameters of all points of this section")
+            static_cast<mitosection_floats_f>(&morphio::mut::MitoSection::diameters),
+            [](morphio::mut::MitoSection* section,
+                const std::vector<float>& _diameters) {
+                section->diameters() = _diameters;
+            },
+            "Returns the diameters of all points of this section")
         .def_property("relative_path_lengths",
-                      &morphio::mut::MitoSection::pathLengths,
-                      [](morphio::mut::MitoSection* section,
-                         const std::vector<float>& _pathLengths) {
-                          section -> pathLengths() = _pathLengths;
-                      },
-                      "Returns the relative distance (between 0 and 1)\n"
-                      "between the start of the neuronal section and each point\n"
-                      "of this mitochondrial section")
+            static_cast<mitosection_floats_f>(&morphio::mut::MitoSection::pathLengths),
+            [](morphio::mut::MitoSection* section,
+                const std::vector<float>& _pathLengths) {
+                section->pathLengths() = _pathLengths;
+            },
+            "Returns the relative distance (between 0 and 1)\n"
+            "between the start of the neuronal section and each point\n"
+            "of this mitochondrial section")
         .def_property("neurite_section_ids",
-                      &morphio::mut::MitoSection::neuriteSectionIds,
-                      [](morphio::mut::MitoSection* section,
-                         const std::vector<uint32_t>& _neuriteSectionIds) {
-                          section -> neuriteSectionIds() = _neuriteSectionIds;
-                      },
-                      "Returns the neurite section Ids of all points of this section")
+            static_cast<mitosection_ints_f>(&morphio::mut::MitoSection::neuriteSectionIds),
+            [](morphio::mut::MitoSection* section,
+                const std::vector<uint32_t>& _neuriteSectionIds) {
+                section->neuriteSectionIds() = _neuriteSectionIds;
+            },
+            "Returns the neurite section Ids of all points of this section")
 
-        .def("append_section", static_cast<std::shared_ptr<morphio::mut::MitoSection> (morphio::mut::MitoSection::*) (const morphio::Property::MitochondriaPointLevel&)>(&morphio::mut::MitoSection::appendSection),
-             "Append a new MitoSection to this mito section",
-             "point_level_properties"_a)
+        .def("append_section", static_cast<std::shared_ptr<morphio::mut::MitoSection> (morphio::mut::MitoSection::*)(const morphio::Property::MitochondriaPointLevel&)>(&morphio::mut::MitoSection::appendSection),
+            "Append a new MitoSection to this mito section",
+            "point_level_properties"_a)
 
-        .def("append_section", static_cast<std::shared_ptr<morphio::mut::MitoSection> (morphio::mut::MitoSection::*) (const std::shared_ptr<morphio::mut::MitoSection>&, bool)>(&morphio::mut::MitoSection::appendSection),
-             "Append a copy of the section to this section\n"
-             "If recursive == true, all descendent will be appended as well",
-             "section"_a, "recursive"_a=false)
+        .def("append_section", static_cast<std::shared_ptr<morphio::mut::MitoSection> (morphio::mut::MitoSection::*)(const std::shared_ptr<morphio::mut::MitoSection>&, bool)>(&morphio::mut::MitoSection::appendSection),
+            "Append a copy of the section to this section\n"
+            "If recursive == true, all descendent will be appended as well",
+            "section"_a, "recursive"_a = false)
 
-        .def("append_section", static_cast<std::shared_ptr<morphio::mut::MitoSection> (morphio::mut::MitoSection::*) (const morphio::MitoSection&, bool)>(&morphio::mut::MitoSection::appendSection),
-             "Append the existing immutable MitoSection to this section\n"
-             "If recursive == true, all descendent will be appended as well",
-             "immutable_section"_a, "recursive"_a=false);
+        .def("append_section", static_cast<std::shared_ptr<morphio::mut::MitoSection> (morphio::mut::MitoSection::*)(const morphio::MitoSection&, bool)>(&morphio::mut::MitoSection::appendSection),
+            "Append the existing immutable MitoSection to this section\n"
+            "If recursive == true, all descendent will be appended as well",
+            "immutable_section"_a, "recursive"_a = false);
 
     py::class_<morphio::mut::Section, std::shared_ptr<morphio::mut::Section>>(m, "Section")
         .def("__str__", [](const morphio::mut::Section& section) {

--- a/include/morphio/enums.h
+++ b/include/morphio/enums.h
@@ -52,7 +52,7 @@ enum MorphologyVersion
     MORPHOLOGY_VERSION_SWC_1 = 101,
     MORPHOLOGY_VERSION_UNDEFINED
 };
-std::ostream& operator<<(std::ostream& os, const MorphologyVersion v);
+std::ostream& operator<<(std::ostream& os, MorphologyVersion v);
 
 
 enum AnnotationType
@@ -75,7 +75,7 @@ enum SomaType
     SOMA_CYLINDERS,
     SOMA_SIMPLE_CONTOUR
 };
-std::ostream& operator<<(std::ostream& os, const SomaType v);
+std::ostream& operator<<(std::ostream& os, SomaType v);
 
 /** Classification of neuron substructures. */
 enum SectionType

--- a/include/morphio/errorMessages.h
+++ b/include/morphio/errorMessages.h
@@ -131,10 +131,10 @@ public:
     std::string ERROR_LINE_NON_PARSABLE(long unsigned int lineNumber) const;
 
     std::string ERROR_UNSUPPORTED_SECTION_TYPE(long unsigned int lineNumber,
-                                                     const SectionType& type) const;
+        const SectionType& type) const;
 
     std::string ERROR_UNSUPPORTED_VASCULATURE_SECTION_TYPE(long unsigned int lineNumber,
-                                                                 const VascularSectionType& type) const;
+        const VascularSectionType& type) const;
 
     std::string ERROR_MULTIPLE_SOMATA(
         const std::vector<Sample>& somata) const;

--- a/include/morphio/errorMessages.h
+++ b/include/morphio/errorMessages.h
@@ -101,7 +101,7 @@ public:
     **/
     static bool isIgnored(Warning warning);
 
-    const std::string errorLink(long unsigned int lineNumber, ErrorLevel errorLevel) const
+    std::string errorLink(long unsigned int lineNumber, ErrorLevel errorLevel) const
     {
         std::map<ErrorLevel, std::string> SEVERITY{{ErrorLevel::INFO, "info"},
             {ErrorLevel::WARNING,
@@ -119,73 +119,73 @@ public:
         return COLOR.at(errorLevel) + _uri + ":" + std::to_string(lineNumber) + ":" + SEVERITY.at(errorLevel) + COLOR_END;
     }
 
-    const std::string errorMsg(long unsigned int lineNumber, ErrorLevel errorLevel,
+    std::string errorMsg(long unsigned int lineNumber, ErrorLevel errorLevel,
         std::string msg = "") const;
 
     ////////////////////////////////////////////////////////////////////////////////
     //              ERRORS
     ////////////////////////////////////////////////////////////////////////////////
 
-    const std::string ERROR_OPENING_FILE() const;
+    std::string ERROR_OPENING_FILE() const;
 
-    const std::string ERROR_LINE_NON_PARSABLE(long unsigned int lineNumber) const;
+    std::string ERROR_LINE_NON_PARSABLE(long unsigned int lineNumber) const;
 
-    const std::string ERROR_UNSUPPORTED_SECTION_TYPE(long unsigned int lineNumber,
+    std::string ERROR_UNSUPPORTED_SECTION_TYPE(long unsigned int lineNumber,
                                                      const SectionType& type) const;
 
-    const std::string ERROR_UNSUPPORTED_VASCULATURE_SECTION_TYPE(long unsigned int lineNumber,
+    std::string ERROR_UNSUPPORTED_VASCULATURE_SECTION_TYPE(long unsigned int lineNumber,
                                                                  const VascularSectionType& type) const;
 
-    const std::string ERROR_MULTIPLE_SOMATA(
+    std::string ERROR_MULTIPLE_SOMATA(
         const std::vector<Sample>& somata) const;
 
-    const std::string ERROR_MISSING_PARENT(const Sample& sample) const;
+    std::string ERROR_MISSING_PARENT(const Sample& sample) const;
 
     std::string ERROR_SOMA_BIFURCATION(
         const Sample& sample, const std::vector<Sample>& children) const;
 
     std::string ERROR_SOMA_WITH_NEURITE_PARENT(const Sample& sample) const;
 
-    const std::string ERROR_REPEATED_ID(const Sample& originalSample,
+    std::string ERROR_REPEATED_ID(const Sample& originalSample,
         const Sample& newSample) const;
 
-    const std::string ERROR_SELF_PARENT(const Sample& sample) const;
+    std::string ERROR_SELF_PARENT(const Sample& sample) const;
 
-    const std::string ERROR_NOT_IMPLEMENTED_UNDEFINED_SOMA(
+    std::string ERROR_NOT_IMPLEMENTED_UNDEFINED_SOMA(
         const std::string&) const;
 
-    const std::string ERROR_MISSING_MITO_PARENT(int mitoParentId) const;
+    std::string ERROR_MISSING_MITO_PARENT(int mitoParentId) const;
 
     ////////////////////////////////////////////////////////////////////////////////
     //             NEUROLUCIDA
     ////////////////////////////////////////////////////////////////////////////////
-    const std::string ERROR_SOMA_ALREADY_DEFINED(long unsigned int lineNumber) const;
+    std::string ERROR_SOMA_ALREADY_DEFINED(long unsigned int lineNumber) const;
 
-    const std::string ERROR_PARSING_POINT(long unsigned int lineNumber,
+    std::string ERROR_PARSING_POINT(long unsigned int lineNumber,
         const std::string& point) const;
 
-    const std::string ERROR_UNKNOWN_TOKEN(long unsigned int lineNumber,
+    std::string ERROR_UNKNOWN_TOKEN(long unsigned int lineNumber,
         const std::string& token) const;
 
-    const std::string ERROR_UNEXPECTED_TOKEN(long unsigned int lineNumber,
+    std::string ERROR_UNEXPECTED_TOKEN(long unsigned int lineNumber,
         const std::string& expected,
         const std::string& got,
         const std::string& msg) const;
 
-    const std::string ERROR_EOF_REACHED(long unsigned int lineNumber) const;
+    std::string ERROR_EOF_REACHED(long unsigned int lineNumber) const;
 
-    const std::string ERROR_EOF_IN_NEURITE(long unsigned int lineNumber) const;
+    std::string ERROR_EOF_IN_NEURITE(long unsigned int lineNumber) const;
 
-    const std::string ERROR_EOF_UNBALANCED_PARENS(long unsigned int lineNumber) const;
+    std::string ERROR_EOF_UNBALANCED_PARENS(long unsigned int lineNumber) const;
 
-    const std::string ERROR_UNCOMPATIBLE_FLAGS(morphio::Option flag1,
+    std::string ERROR_UNCOMPATIBLE_FLAGS(morphio::Option flag1,
         morphio::Option flag2) const;
 
     ////////////////////////////////////////////////////////////////////////////////
     //              WRITERS
     ////////////////////////////////////////////////////////////////////////////////
 
-    const std::string ERROR_WRONG_EXTENSION(const std::string filename) const;
+    std::string ERROR_WRONG_EXTENSION(const std::string& filename) const;
 
     std::string ERROR_VECTOR_LENGTH_MISMATCH(const std::string& vec1,
         size_t length1,
@@ -204,10 +204,10 @@ public:
         std::shared_ptr<morphio::mut::Section> current,
         std::shared_ptr<morphio::mut::Section> parent) const;
     std::string WARNING_APPENDING_EMPTY_SECTION(std::shared_ptr<morphio::mut::Section>);
-    const std::string WARNING_ONLY_CHILD(const DebugInfo& info, unsigned int parentId,
+    std::string WARNING_ONLY_CHILD(const DebugInfo& info, unsigned int parentId,
         unsigned int childId) const;
 
-    const std::string WARNING_NEUROMORPHO_SOMA_NON_CONFORM(
+    std::string WARNING_NEUROMORPHO_SOMA_NON_CONFORM(
         const Sample& root, const Sample& child1, const Sample& child2);
 
     std::string WARNING_WRONG_ROOT_POINT(

--- a/include/morphio/exceptions.h
+++ b/include/morphio/exceptions.h
@@ -8,7 +8,7 @@ namespace morphio {
 class MorphioError : public std::runtime_error
 {
 public:
-    MorphioError(const std::string& _msg)
+    explicit MorphioError(const std::string& _msg)
         : std::runtime_error(_msg)
     {
     }
@@ -17,7 +17,7 @@ public:
 class NotImplementedError : public MorphioError
 {
 public:
-    NotImplementedError(const std::string& _msg)
+    explicit NotImplementedError(const std::string& _msg)
         : MorphioError(_msg)
     {
     }
@@ -26,7 +26,7 @@ public:
 class RawDataError : public MorphioError
 {
 public:
-    RawDataError(const std::string& _msg)
+    explicit RawDataError(const std::string& _msg)
         : MorphioError(_msg)
     {
     }
@@ -35,7 +35,7 @@ public:
 class UnknownFileType : public MorphioError
 {
 public:
-    UnknownFileType(const std::string& _msg)
+    explicit UnknownFileType(const std::string& _msg)
         : MorphioError(_msg)
     {
     }
@@ -44,7 +44,7 @@ public:
 class SomaError : public MorphioError
 {
 public:
-    SomaError(const std::string& _msg)
+    explicit SomaError(const std::string& _msg)
         : MorphioError(_msg)
     {
     }
@@ -53,7 +53,7 @@ public:
 class IDSequenceError : public RawDataError
 {
 public:
-    IDSequenceError(const std::string& _msg)
+    explicit IDSequenceError(const std::string& _msg)
         : RawDataError(_msg)
     {
     }
@@ -62,7 +62,7 @@ public:
 class MultipleTrees : public RawDataError
 {
 public:
-    MultipleTrees(const std::string& _msg)
+    explicit MultipleTrees(const std::string& _msg)
         : RawDataError(_msg)
     {
     }
@@ -71,7 +71,7 @@ public:
 class MissingParentError : public RawDataError
 {
 public:
-    MissingParentError(const std::string& _msg)
+    explicit MissingParentError(const std::string& _msg)
         : RawDataError(_msg)
     {
     }
@@ -80,7 +80,7 @@ public:
 class SectionBuilderError : public RawDataError
 {
 public:
-    SectionBuilderError(const std::string& _msg)
+    explicit SectionBuilderError(const std::string& _msg)
         : RawDataError(_msg)
     {
     }
@@ -89,7 +89,7 @@ public:
 class WriterError : public MorphioError
 {
 public:
-    WriterError(const std::string& _msg)
+    explicit WriterError(const std::string& _msg)
         : MorphioError(_msg)
     {
     }

--- a/include/morphio/mito_section.h
+++ b/include/morphio/mito_section.h
@@ -37,12 +37,12 @@ public:
     /**
      * Returns list of neuronal section IDs associated to each point
      **/
-    const range<const uint32_t> neuriteSectionIds() const;
+    range<const uint32_t> neuriteSectionIds() const;
 
     /**
      * Returns list of section's point diameters
      **/
-    const range<const float> diameters() const;
+    range<const float> diameters() const;
 
     /**
      * Returns list of relative distances between the start
@@ -52,17 +52,17 @@ public:
      *       - a relative distance of 1 means the mitochondrial point is at the
      *         end of the neuronal section
      **/
-    const range<const float> relativePathLengths() const;
+    range<const float> relativePathLengths() const;
 
     /** Return the morphological type of this section (dendrite, axon, ...). */
     SectionType type() const;
 
 protected:
-    MitoSection(uint32_t id_, std::shared_ptr<Property::Properties> morphology)
+    MitoSection(uint32_t id_, const std::shared_ptr<Property::Properties>& morphology)
         : SectionBase(id_, morphology)
     {
     }
-    friend const MitoSection Mitochondria::section(const uint32_t&) const;
+    friend MitoSection Mitochondria::section(uint32_t) const;
     friend class SectionBase<MitoSection>;
     friend class mut::MitoSection;
 };

--- a/include/morphio/mitochondria.h
+++ b/include/morphio/mitochondria.h
@@ -14,12 +14,12 @@ namespace morphio {
 class Mitochondria
 {
 public:
-    const MitoSection section(const uint32_t& id) const;
-    const std::vector<MitoSection> rootSections() const;
-    const std::vector<MitoSection> sections() const;
+    MitoSection section(uint32_t id) const;
+    std::vector<MitoSection> rootSections() const;
+    std::vector<MitoSection> sections() const;
 
 private:
-    Mitochondria(std::shared_ptr<Property::Properties> properties)
+    explicit Mitochondria(const std::shared_ptr<Property::Properties>& properties)
         : _properties(properties)
     {
     }

--- a/include/morphio/morphology.h
+++ b/include/morphio/morphology.h
@@ -27,8 +27,8 @@ public:
     virtual ~Morphology();
 
     Morphology& operator=(const Morphology&);
-    Morphology(Morphology&&);
-    Morphology& operator=(Morphology&&);
+    Morphology(Morphology&&) noexcept;
+    Morphology& operator=(Morphology&&) noexcept;
 
     /** @name Read API */
     //@{
@@ -40,8 +40,8 @@ public:
         Example:
             Morphology("neuron.asc", TWO_POINTS_SECTIONS | SOMA_SPHERE);
      */
-    Morphology(const URI& source, unsigned int options = NO_MODIFIER);
-    Morphology(mut::Morphology);
+    explicit Morphology(const URI& source, unsigned int options = NO_MODIFIER);
+    explicit Morphology(mut::Morphology);
 
     /**
      * Return the soma object
@@ -74,13 +74,13 @@ public:
      *
      * @throw RawDataError if the id is out of range
      */
-    Section section(const uint32_t& id) const;
+    Section section(uint32_t id) const;
 
     /**
      * Return a vector with all points from all sections
      * (soma points are not included)
      **/
-    const Points& points() const;
+    const Points& points() const noexcept;
 
     /**
      * Returns a list with offsets to access data of a specific section in the points

--- a/include/morphio/mut/mito_section.h
+++ b/include/morphio/mut/mito_section.h
@@ -25,9 +25,9 @@ public:
     std::shared_ptr<MitoSection> appendSection(
         const morphio::MitoSection& section, bool recursive);
 
-    const std::shared_ptr<MitoSection> parent() const;
+    std::shared_ptr<MitoSection> parent() const;
     bool isRoot() const;
-    const std::vector<std::shared_ptr<MitoSection>> children() const;
+    const std::vector<std::shared_ptr<MitoSection>>& children() const;
 
     /**
      * Return the section id

--- a/include/morphio/mut/mito_section.h
+++ b/include/morphio/mut/mito_section.h
@@ -20,7 +20,7 @@ public:
         const Property::MitochondriaPointLevel& points);
 
     std::shared_ptr<MitoSection> appendSection(
-        std::shared_ptr<MitoSection> original_section, bool recursive);
+        const std::shared_ptr<MitoSection>& original_section, bool recursive);
 
     std::shared_ptr<MitoSection> appendSection(
         const morphio::MitoSection& section, bool recursive);
@@ -32,15 +32,15 @@ public:
     /**
      * Return the section id
      **/
-    uint32_t id() const { return _id; }
+    uint32_t id() const noexcept { return _id; }
     /**
      * Return the diameters of all points of this section
      **/
-    std::vector<float>& diameters() { return _mitoPoints._diameters; }
+    std::vector<float>& diameters() noexcept { return _mitoPoints._diameters; }
     /**
      * Return the neurite section Ids of all points of this section
      **/
-    std::vector<uint32_t>& neuriteSectionIds()
+    std::vector<uint32_t>& neuriteSectionIds() noexcept
     {
         return _mitoPoints._sectionIds;
     }
@@ -50,13 +50,12 @@ public:
      * between the start of the neuronal section and each point
      * of this mitochondrial section
      **/
-    std::vector<float>& pathLengths()
+    std::vector<float>& pathLengths() noexcept
     {
         return _mitoPoints._relativePathLengths;
     }
 
 private:
-    friend void friendDtorForSharedPtr(Section*);
     uint32_t _id;
 
     Mitochondria* _mitochondria;
@@ -65,8 +64,6 @@ public:
     // TODO: make private
     Property::MitochondriaPointLevel _mitoPoints;
 };
-
-void friendDtorForSharedPtrMito(MitoSection* section);
 
 } // namespace mut
 } // namespace morphio

--- a/include/morphio/mut/mito_section.h
+++ b/include/morphio/mut/mito_section.h
@@ -32,28 +32,30 @@ public:
     /**
      * Return the section id
      **/
-    uint32_t id() const noexcept { return _id; }
-    /**
+    inline uint32_t id() const noexcept;
+
+    /** @{
      * Return the diameters of all points of this section
      **/
-    std::vector<float>& diameters() noexcept { return _mitoPoints._diameters; }
-    /**
+    inline const std::vector<float>& diameters() const noexcept;
+    inline std::vector<float>& diameters() noexcept;
+    /** @} */
+
+    /** @{
      * Return the neurite section Ids of all points of this section
      **/
-    std::vector<uint32_t>& neuriteSectionIds() noexcept
-    {
-        return _mitoPoints._sectionIds;
-    }
+    inline const std::vector<uint32_t>& neuriteSectionIds() const noexcept;
+    inline std::vector<uint32_t>& neuriteSectionIds() noexcept;
+    /** @} */
 
-    /**
+    /** @{
      * Return the relative distance (between 0 and 1)
      * between the start of the neuronal section and each point
      * of this mitochondrial section
      **/
-    std::vector<float>& pathLengths() noexcept
-    {
-        return _mitoPoints._relativePathLengths;
-    }
+    inline const std::vector<float>& pathLengths() const noexcept;
+    inline std::vector<float>& pathLengths() noexcept;
+    /** @} */
 
 private:
     uint32_t _id;
@@ -64,6 +66,43 @@ public:
     // TODO: make private
     Property::MitochondriaPointLevel _mitoPoints;
 };
+
+inline uint32_t MitoSection::id() const noexcept
+{
+    return _id;
+}
+
+inline const std::vector<float>& MitoSection::diameters() const noexcept
+{
+    return _mitoPoints._diameters;
+}
+
+inline const std::vector<uint32_t>& MitoSection::neuriteSectionIds() const noexcept
+{
+    return _mitoPoints._sectionIds;
+}
+
+inline const std::vector<float>& MitoSection::pathLengths() const noexcept
+{
+    return _mitoPoints._relativePathLengths;
+}
+
+inline std::vector<float>& MitoSection::diameters() noexcept
+{
+    return _mitoPoints._diameters;
+}
+
+inline std::vector<uint32_t>& MitoSection::neuriteSectionIds() noexcept
+{
+    return _mitoPoints._sectionIds;
+}
+
+inline std::vector<float>& MitoSection::pathLengths() noexcept
+{
+    return _mitoPoints._relativePathLengths;
+}
+
+void friendDtorForSharedPtrMito(MitoSection* section);
 
 } // namespace mut
 } // namespace morphio

--- a/include/morphio/mut/mitochondria.h
+++ b/include/morphio/mut/mitochondria.h
@@ -33,9 +33,9 @@ public:
     {
     }
 
-    const std::vector<MitoSectionP> children(MitoSectionP) const;
-    const MitoSectionP section(uint32_t id) const;
-    const std::map<uint32_t, MitoSectionP> sections() const;
+    std::vector<MitoSectionP> children(const MitoSectionP&) const;
+    const MitoSectionP& section(uint32_t id) const;
+    const std::map<uint32_t, MitoSectionP>& sections() const;
 
     /**
        Depth first iterator starting at a given section id
@@ -43,7 +43,7 @@ public:
        If id == -1, the iteration will start at each root section, successively
     **/
     mito_depth_iterator depth_begin() const;
-    mito_depth_iterator depth_begin(const MitoSectionP section) const;
+    mito_depth_iterator depth_begin(const MitoSectionP& section) const;
     mito_depth_iterator depth_end() const;
 
     /**
@@ -53,7 +53,7 @@ public:
        at each root section
     **/
     mito_breadth_iterator breadth_begin() const;
-    mito_breadth_iterator breadth_begin(const MitoSectionP section) const;
+    mito_breadth_iterator breadth_begin(const MitoSectionP& section) const;
     mito_breadth_iterator breadth_end() const;
 
     /**
@@ -63,24 +63,24 @@ public:
        at each root section
     **/
     mito_upstream_iterator upstream_begin() const;
-    mito_upstream_iterator upstream_begin(const MitoSectionP section) const;
+    mito_upstream_iterator upstream_begin(const MitoSectionP& section) const;
     mito_upstream_iterator upstream_end() const;
 
     /**
      * Return the parent mithochondrial section ID
      **/
-    const MitoSectionP parent(const MitoSectionP parent) const;
+    const MitoSectionP& parent(const MitoSectionP& parent) const;
 
     /**
        Return true if section is a root section
     **/
-    bool isRoot(const MitoSectionP section) const;
+    bool isRoot(const MitoSectionP& section) const;
 
     /**
      * Return the list of IDs of all mitochondrial root sections
      * (sections whose parent ID are -1)
      **/
-    const std::vector<MitoSectionP>& rootSections() const;
+    const std::vector<MitoSectionP>& rootSections() const noexcept;
 
     /**
        Append a new root MitoSection
@@ -96,7 +96,7 @@ public:
     **/
     MitoSectionP appendRootSection(const morphio::MitoSection&,
         bool recursive = false);
-    MitoSectionP appendRootSection(const MitoSectionP, bool recursive = false);
+    MitoSectionP appendRootSection(const MitoSectionP&, bool recursive = false);
 
     const MitoSectionP mitoSection(uint32_t id) const;
 
@@ -105,7 +105,7 @@ public:
 private:
     friend class MitoSection;
 
-    uint32_t _register(MitoSectionP section);
+    uint32_t _register(const MitoSectionP& section);
 
     uint32_t _counter;
     std::map<uint32_t, std::vector<MitoSectionP>> _children;

--- a/include/morphio/mut/mitochondria.h
+++ b/include/morphio/mut/mitochondria.h
@@ -35,9 +35,7 @@ public:
 
     const std::vector<MitoSectionP>& children(const MitoSectionP&) const;
     const MitoSectionP& section(uint32_t id) const;
-    const std::map<uint32_t, MitoSectionP>& sections() const noexcept {
-        return _sections;
-    }
+    const std::map<uint32_t, MitoSectionP>& sections() const noexcept;
 
     /**
        Depth first iterator starting at a given section id
@@ -82,9 +80,7 @@ public:
      * Return the list of IDs of all mitochondrial root sections
      * (sections whose parent ID are -1)
      **/
-    const std::vector<MitoSectionP>& rootSections() const noexcept {
-        return _rootSections;
-    }
+    const std::vector<MitoSectionP>& rootSections() const noexcept;
 
     /**
        Append a new root MitoSection
@@ -117,5 +113,16 @@ private:
     std::vector<MitoSectionP> _rootSections;
     std::map<uint32_t, MitoSectionP> _sections;
 };
+
+inline const std::map<uint32_t, Mitochondria::MitoSectionP>& Mitochondria::sections() const noexcept
+{
+    return _sections;
+}
+
+inline const std::vector<Mitochondria::MitoSectionP>& Mitochondria::rootSections() const noexcept
+{
+    return _rootSections;
+}
+
 } // namespace mut
 } // namespace morphio

--- a/include/morphio/mut/mitochondria.h
+++ b/include/morphio/mut/mitochondria.h
@@ -33,9 +33,11 @@ public:
     {
     }
 
-    std::vector<MitoSectionP> children(const MitoSectionP&) const;
+    const std::vector<MitoSectionP>& children(const MitoSectionP&) const;
     const MitoSectionP& section(uint32_t id) const;
-    const std::map<uint32_t, MitoSectionP>& sections() const;
+    const std::map<uint32_t, MitoSectionP>& sections() const noexcept {
+        return _sections;
+    }
 
     /**
        Depth first iterator starting at a given section id
@@ -80,7 +82,9 @@ public:
      * Return the list of IDs of all mitochondrial root sections
      * (sections whose parent ID are -1)
      **/
-    const std::vector<MitoSectionP>& rootSections() const noexcept;
+    const std::vector<MitoSectionP>& rootSections() const noexcept {
+        return _rootSections;
+    }
 
     /**
        Append a new root MitoSection
@@ -98,7 +102,7 @@ public:
         bool recursive = false);
     MitoSectionP appendRootSection(const MitoSectionP&, bool recursive = false);
 
-    const MitoSectionP mitoSection(uint32_t id) const;
+    const MitoSectionP& mitoSection(uint32_t id) const;
 
     void _buildMitochondria(Property::Properties& properties) const;
 

--- a/include/morphio/mut/morphology.h
+++ b/include/morphio/mut/morphology.h
@@ -58,14 +58,16 @@ public:
     /**
        Returns all section ids at the tree root
     **/
-    const std::vector<std::shared_ptr<Section>>& rootSections() const noexcept {
+    const std::vector<std::shared_ptr<Section>>& rootSections() const noexcept
+    {
         return _rootSections;
     }
 
     /**
        Returns the dictionary id -> Section for this tree
     **/
-    const std::map<uint32_t, std::shared_ptr<Section>>& sections() const noexcept {
+    const std::map<uint32_t, std::shared_ptr<Section>>& sections() const noexcept
+    {
         return _sections;
     }
 
@@ -74,10 +76,12 @@ public:
 
        Note: multiple morphologies can share the same Soma instance
     **/
-    std::shared_ptr<Soma>& soma() noexcept {
+    std::shared_ptr<Soma>& soma() noexcept
+    {
         return _soma;
     }
-    const std::shared_ptr<Soma>& soma() const noexcept {
+    const std::shared_ptr<Soma>& soma() const noexcept
+    {
         return _soma;
     }
 
@@ -89,7 +93,8 @@ public:
     /**
      * Return the annotation object
      **/
-    const std::vector<Property::Annotation>& annotations() const noexcept {
+    const std::vector<Property::Annotation>& annotations() const noexcept
+    {
         return _annotations;
     }
 
@@ -98,7 +103,8 @@ public:
 
        Note: multiple morphologies can share the same Section instances.
     **/
-    const std::shared_ptr<Section>& section(uint32_t id) const {
+    const std::shared_ptr<Section>& section(uint32_t id) const
+    {
         return _sections.at(id);
     }
 

--- a/include/morphio/mut/morphology.h
+++ b/include/morphio/mut/morphology.h
@@ -58,55 +58,46 @@ public:
     /**
        Returns all section ids at the tree root
     **/
-    const std::vector<std::shared_ptr<Section>>& rootSections() const noexcept
-    {
-        return _rootSections;
-    }
+    inline const std::vector<std::shared_ptr<Section>>& rootSections() const noexcept;
 
     /**
        Returns the dictionary id -> Section for this tree
     **/
-    const std::map<uint32_t, std::shared_ptr<Section>>& sections() const noexcept
-    {
-        return _sections;
-    }
+    inline const std::map<uint32_t, std::shared_ptr<Section>>& sections() const noexcept;
 
     /**
        Returns a shared pointer on the Soma
 
        Note: multiple morphologies can share the same Soma instance
     **/
-    std::shared_ptr<Soma>& soma() noexcept
-    {
-        return _soma;
-    }
-    const std::shared_ptr<Soma>& soma() const noexcept
-    {
-        return _soma;
-    }
+    inline std::shared_ptr<Soma>& soma() noexcept;
+
+    /**
+       Returns a shared pointer on the Soma
+
+       Note: multiple morphologies can share the same Soma instance
+    **/
+    inline const std::shared_ptr<Soma>& soma() const noexcept;
 
     /**
      * Return the mitochondria container class
      **/
-    Mitochondria& mitochondria() noexcept { return _mitochondria; }
-    const Mitochondria& mitochondria() const noexcept { return _mitochondria; }
+    inline Mitochondria& mitochondria() noexcept;
+    /**
+     * Return the mitochondria container class
+     **/
+    inline const Mitochondria& mitochondria() const noexcept;
     /**
      * Return the annotation object
      **/
-    const std::vector<Property::Annotation>& annotations() const noexcept
-    {
-        return _annotations;
-    }
+    inline const std::vector<Property::Annotation>& annotations() const noexcept;
 
     /**
        Get the shared pointer for the given section
 
        Note: multiple morphologies can share the same Section instances.
     **/
-    const std::shared_ptr<Section>& section(uint32_t id) const
-    {
-        return _sections.at(id);
-    }
+    inline const std::shared_ptr<Section>& section(uint32_t id) const;
 
     /**
        Depth first iterator starting at a given section id
@@ -168,27 +159,24 @@ public:
     /**
      * Return the soma type
      **/
-    SomaType somaType() const noexcept { return _soma->type(); }
+    inline SomaType somaType() const noexcept;
 
     /**
      * Return the cell family (neuron or glia)
      **/
-    CellFamily cellFamily() const noexcept { return _cellProperties->_cellFamily; }
+    inline CellFamily cellFamily() const noexcept;
 
     /**
      * Return the version
      **/
-    MorphologyVersion version() const noexcept { return _cellProperties->_version; }
+    inline MorphologyVersion version() const noexcept;
 
     /**
      * Write file to H5, SWC, ASC format depending on filename extension
      **/
     void write(const std::string& filename);
 
-    void addAnnotation(const morphio::Property::Annotation& annotation)
-    {
-        _annotations.push_back(annotation);
-    }
+    inline void addAnnotation(const morphio::Property::Annotation& annotation);
 
     /**
        Return the data structure used to create read-only morphologies
@@ -222,6 +210,66 @@ private:
     std::map<uint32_t, uint32_t> _parent;
     std::map<uint32_t, std::vector<std::shared_ptr<Section>>> _children;
 };
+
+inline const std::vector<std::shared_ptr<Section>>& Morphology::rootSections() const noexcept
+{
+    return _rootSections;
+}
+
+inline const std::map<uint32_t, std::shared_ptr<Section>>& Morphology::sections() const noexcept
+{
+    return _sections;
+}
+
+inline std::shared_ptr<Soma>& Morphology::soma() noexcept
+{
+    return _soma;
+}
+
+inline const std::shared_ptr<Soma>& Morphology::soma() const noexcept
+{
+    return _soma;
+}
+
+inline Mitochondria& Morphology::mitochondria() noexcept
+{
+    return _mitochondria;
+}
+
+inline const Mitochondria& Morphology::mitochondria() const noexcept
+{
+    return _mitochondria;
+}
+
+inline const std::vector<Property::Annotation>& Morphology::annotations() const noexcept
+{
+    return _annotations;
+}
+
+inline const std::shared_ptr<Section>& Morphology::section(uint32_t id) const
+{
+    return _sections.at(id);
+}
+
+inline SomaType Morphology::somaType() const noexcept
+{
+    return _soma->type();
+}
+
+inline CellFamily Morphology::cellFamily() const noexcept
+{
+    return _cellProperties->_cellFamily;
+}
+
+inline MorphologyVersion Morphology::version() const noexcept
+{
+    return _cellProperties->_version;
+}
+
+inline void Morphology::addAnnotation(const morphio::Property::Annotation& annotation)
+{
+    _annotations.push_back(annotation);
+}
 
 } // namespace mut
 } // namespace morphio

--- a/include/morphio/mut/morphology.h
+++ b/include/morphio/mut/morphology.h
@@ -18,8 +18,8 @@
 
 namespace morphio {
 namespace mut {
-bool _checkDuplicatePoint(std::shared_ptr<Section> parent,
-    std::shared_ptr<Section> current);
+bool _checkDuplicatePoint(const std::shared_ptr<Section>& parent,
+    const std::shared_ptr<Section>& current);
 
 class Morphology
 {
@@ -58,37 +58,49 @@ public:
     /**
        Returns all section ids at the tree root
     **/
-    const std::vector<std::shared_ptr<Section>>& rootSections() const;
+    const std::vector<std::shared_ptr<Section>>& rootSections() const noexcept {
+        return _rootSections;
+    }
 
     /**
        Returns the dictionary id -> Section for this tree
     **/
-    const std::map<uint32_t, std::shared_ptr<Section>> sections() const;
+    const std::map<uint32_t, std::shared_ptr<Section>>& sections() const noexcept {
+        return _sections;
+    }
 
     /**
        Returns a shared pointer on the Soma
 
        Note: multiple morphologies can share the same Soma instance
     **/
-    std::shared_ptr<Soma> soma();
-    const std::shared_ptr<Soma> soma() const;
+    std::shared_ptr<Soma>& soma() noexcept {
+        return _soma;
+    }
+    const std::shared_ptr<Soma>& soma() const noexcept {
+        return _soma;
+    }
 
     /**
      * Return the mitochondria container class
      **/
-    Mitochondria& mitochondria() { return _mitochondria; }
-    const Mitochondria& mitochondria() const { return _mitochondria; }
+    Mitochondria& mitochondria() noexcept { return _mitochondria; }
+    const Mitochondria& mitochondria() const noexcept { return _mitochondria; }
     /**
      * Return the annotation object
      **/
-    const std::vector<Property::Annotation> annotations() const;
+    const std::vector<Property::Annotation>& annotations() const noexcept {
+        return _annotations;
+    }
 
     /**
        Get the shared pointer for the given section
 
        Note: multiple morphologies can share the same Section instances.
     **/
-    const std::shared_ptr<Section> section(uint32_t id) const;
+    const std::shared_ptr<Section>& section(uint32_t id) const {
+        return _sections.at(id);
+    }
 
     /**
        Depth first iterator starting at a given section id
@@ -121,7 +133,7 @@ public:
        If recursive == true, all descendent sections will be deleted as well
        Else, children will be re-attached to their grand-parent
     **/
-    void deleteSection(std::shared_ptr<Section> section, bool recursive = true);
+    void deleteSection(const std::shared_ptr<Section>& section, bool recursive = true);
 
     /**
        Append the existing morphio::Section as a root section
@@ -136,7 +148,7 @@ public:
 
        If recursive == true, all descendent will be appended as well
     **/
-    std::shared_ptr<Section> appendRootSection(std::shared_ptr<Section> section,
+    std::shared_ptr<Section> appendRootSection(const std::shared_ptr<Section>& section,
         bool recursive = false);
 
     /**
@@ -150,17 +162,17 @@ public:
     /**
      * Return the soma type
      **/
-    SomaType somaType() { return _soma->type(); }
+    SomaType somaType() const noexcept { return _soma->type(); }
 
     /**
      * Return the cell family (neuron or glia)
      **/
-    CellFamily& cellFamily() { return _cellProperties->_cellFamily; }
+    CellFamily cellFamily() const noexcept { return _cellProperties->_cellFamily; }
 
     /**
      * Return the version
      **/
-    MorphologyVersion& version() { return _cellProperties->_version; }
+    MorphologyVersion version() const noexcept { return _cellProperties->_version; }
 
     /**
      * Write file to H5, SWC, ASC format depending on filename extension
@@ -175,7 +187,7 @@ public:
     /**
        Return the data structure used to create read-only morphologies
     **/
-    const Property::Properties buildReadOnly() const;
+    Property::Properties buildReadOnly() const;
 
     /**
        Check that the neuron is valid, issue warning and fix unifurcations
@@ -191,7 +203,7 @@ private:
                      morphio::enums::LogLevel verbose);
     morphio::readers::ErrorMessages _err;
 
-    uint32_t _register(std::shared_ptr<Section>);
+    uint32_t _register(const std::shared_ptr<Section>&);
 
     uint32_t _counter;
     std::shared_ptr<Soma> _soma;

--- a/include/morphio/mut/section.h
+++ b/include/morphio/mut/section.h
@@ -18,48 +18,47 @@ using depth_iterator = morphio::depth_iterator_t<std::shared_ptr<Section>, Morph
 class Section : public std::enable_shared_from_this<Section>
 {
 public:
-    ~Section() {}
+    ~Section() = default;
 
     /**
      * Return the section ID
      **/
-    uint32_t id() const { return _id; }
-    /**
+    inline uint32_t id() const noexcept;
+
+    /** @{
      * Return the morphological type of this section (dendrite, axon, ...)
      **/
-    SectionType& type() { return _sectionType; }
-    const SectionType& type() const { return _sectionType; }
-    /**
+    inline SectionType& type() noexcept;
+    inline const SectionType& type() const noexcept;
+    /** @} */
+
+    /** @{
        Return the coordinates (x,y,z) of all points of this section
     **/
-    std::vector<Point>& points() { return _pointProperties._points; }
-    const std::vector<Point>& points() const
-    {
-        return _pointProperties._points;
-    }
+    inline std::vector<Point>& points() noexcept;
+    inline const std::vector<Point>& points() const noexcept;
+    /** @} */
 
-    /**
+    /** @{
        Return the diameters of all points of this section
     **/
-    std::vector<float>& diameters() { return _pointProperties._diameters; }
-    const std::vector<float>& diameters() const
-    {
-        return _pointProperties._diameters;
-    }
+    inline std::vector<float>& diameters() noexcept;
+    inline const std::vector<float>& diameters() const noexcept;
+    /** @} */
 
-    /**
+    /** @{
        Return the perimeters of all points of this section
     **/
-    std::vector<float>& perimeters() { return _pointProperties._perimeters; }
-    const std::vector<float>& perimeters() const
-    {
-        return _pointProperties._perimeters;
-    }
+    inline std::vector<float>& perimeters() noexcept;
+    inline const std::vector<float>& perimeters() const noexcept;
+    /** @} */
 
-    /**
+    /** @{
        Return the PointLevel instance that contains this section's data
     **/
-    Property::PointLevel& properties() { return _pointProperties; }
+    inline Property::PointLevel& properties() noexcept;
+    inline const Property::PointLevel& properties() const noexcept;
+    /** @} */
     ////////////////////////////////////////////////////////////////////////////////
     //
     // Methods that were previously in mut::Morphology
@@ -116,6 +115,61 @@ private:
 };
 
 std::ostream& operator<<(std::ostream&, const std::shared_ptr<Section>&);
+
+inline uint32_t Section::id() const noexcept
+{
+    return _id;
+}
+
+inline SectionType& Section::type() noexcept
+{
+    return _sectionType;
+}
+
+inline const SectionType& Section::type() const noexcept
+{
+    return _sectionType;
+}
+
+inline std::vector<Point>& Section::points() noexcept
+{
+    return _pointProperties._points;
+}
+
+inline const std::vector<Point>& Section::points() const noexcept
+{
+    return _pointProperties._points;
+}
+
+inline std::vector<float>& Section::diameters() noexcept
+{
+    return _pointProperties._diameters;
+}
+
+inline const std::vector<float>& Section::diameters() const noexcept
+{
+    return _pointProperties._diameters;
+}
+
+inline std::vector<float>& Section::perimeters() noexcept
+{
+    return _pointProperties._perimeters;
+}
+
+inline const std::vector<float>& Section::perimeters() const noexcept
+{
+    return _pointProperties._perimeters;
+}
+
+inline Property::PointLevel& Section::properties() noexcept
+{
+    return _pointProperties;
+}
+
+inline const Property::PointLevel& Section::properties() const noexcept
+{
+    return _pointProperties;
+}
 
 } // namespace mut
 } // namespace morphio

--- a/include/morphio/mut/section.h
+++ b/include/morphio/mut/section.h
@@ -71,7 +71,7 @@ public:
 
        Note: Root sections return -1
     **/
-    const std::shared_ptr<Section> parent() const;
+    const std::shared_ptr<Section>& parent() const;
 
     /**
        Return true if section is a root section
@@ -81,7 +81,7 @@ public:
     /**
        Return a vector of children IDs
     **/
-    const std::vector<std::shared_ptr<Section>> children() const;
+    const std::vector<std::shared_ptr<Section>>& children() const;
 
     depth_iterator depth_begin() const;
     depth_iterator depth_end() const;
@@ -105,10 +105,6 @@ public:
 private:
     friend class Morphology;
 
-    // The joy of C++:
-    // https://stackoverflow.com/questions/8202530/how-can-i-call-a-private-destructor-from-a-shared-ptr
-    friend void friendDtorForSharedPtr(Section*);
-
     Section(Morphology*, unsigned int id, SectionType type, const Property::PointLevel&);
     Section(Morphology*, unsigned int id, const morphio::Section& section);
     Section(Morphology*, unsigned int id, const Section&);
@@ -119,9 +115,7 @@ private:
     SectionType _sectionType;
 };
 
-void friendDtorForSharedPtr(Section* section);
-
-std::ostream& operator<<(std::ostream&, std::shared_ptr<Section>);
+std::ostream& operator<<(std::ostream&, const std::shared_ptr<Section>&);
 
 } // namespace mut
 } // namespace morphio

--- a/include/morphio/mut/soma.h
+++ b/include/morphio/mut/soma.h
@@ -16,30 +16,24 @@ public:
     Soma(const Soma& soma);
     Soma(const morphio::Soma& soma);
 
-    ~Soma() {}
-    /**
+    /** @{
        Return the coordinates (x,y,z) of all soma point
     **/
-    std::vector<Point>& points() noexcept { return _pointProperties._points; }
-
-    const std::vector<Point>& points() const noexcept
-    {
-        return _pointProperties._points;
-    }
+    inline std::vector<Point>& points() noexcept;
+    inline const std::vector<Point>& points() const noexcept;
+    /** @} */
 
     /**
        Return the diameters of all soma points
     **/
-    std::vector<float>& diameters() noexcept { return _pointProperties._diameters; }
-    const std::vector<float>& diameters() const noexcept
-    {
-        return _pointProperties._diameters;
-    }
+    inline std::vector<float>& diameters() noexcept;
+    inline const std::vector<float>& diameters() const noexcept;
+    /** @} */
 
     /**
        Return the soma type
     **/
-    SomaType type() const noexcept { return _somaType; }
+    inline SomaType type() const noexcept;
     /**
      * Return the center of gravity of the soma points
      **/
@@ -57,12 +51,49 @@ public:
      */
     float maxDistance() const;
 
-    Property::PointLevel& properties() { return _pointProperties; }
+    inline Property::PointLevel& properties() noexcept;
+    inline const Property::PointLevel& properties() const noexcept;
+
 private:
     friend class Morphology;
     SomaType _somaType;
     Property::PointLevel _pointProperties;
 };
+
+inline std::vector<Point>& Soma::points() noexcept
+{
+    return _pointProperties._points;
+}
+
+const std::vector<Point>& Soma::points() const noexcept
+{
+    return _pointProperties._points;
+}
+
+inline std::vector<float>& Soma::diameters() noexcept
+{
+    return _pointProperties._diameters;
+}
+
+const std::vector<float>& Soma::diameters() const noexcept
+{
+    return _pointProperties._diameters;
+}
+
+inline SomaType Soma::type() const noexcept
+{
+    return _somaType;
+}
+
+inline Property::PointLevel& Soma::properties() noexcept
+{
+    return _pointProperties;
+}
+
+inline const Property::PointLevel& Soma::properties() const noexcept
+{
+    return _pointProperties;
+}
 
 std::ostream& operator<<(std::ostream& os, const std::shared_ptr<Soma>& sectionPtr);
 std::ostream& operator<<(std::ostream& os, const Soma& soma);

--- a/include/morphio/mut/soma.h
+++ b/include/morphio/mut/soma.h
@@ -29,8 +29,8 @@ public:
     /**
        Return the diameters of all soma points
     **/
-    std::vector<float>& diameters() { return _pointProperties._diameters; }
-    const std::vector<float>& diameters() const
+    std::vector<float>& diameters() noexcept { return _pointProperties._diameters; }
+    const std::vector<float>& diameters() const noexcept
     {
         return _pointProperties._diameters;
     }
@@ -38,11 +38,11 @@ public:
     /**
        Return the soma type
     **/
-    SomaType type() const { return _somaType; }
+    SomaType type() const noexcept { return _somaType; }
     /**
      * Return the center of gravity of the soma points
      **/
-    const Point center() const;
+    Point center() const;
 
     /**
        Return the soma surface
@@ -63,8 +63,8 @@ private:
     Property::PointLevel _pointProperties;
 };
 
-std::ostream& operator<<(std::ostream& os, std::shared_ptr<Soma> sectionPtr);
-std::ostream& operator<<(std::ostream& os, Soma& soma);
+std::ostream& operator<<(std::ostream& os, const std::shared_ptr<Soma>& sectionPtr);
+std::ostream& operator<<(std::ostream& os, const Soma& soma);
 
 } // namespace mut
 } // namespace morphio

--- a/include/morphio/mut/soma.h
+++ b/include/morphio/mut/soma.h
@@ -20,8 +20,9 @@ public:
     /**
        Return the coordinates (x,y,z) of all soma point
     **/
-    std::vector<Point>& points() { return _pointProperties._points; }
-    const std::vector<Point>& points() const
+    std::vector<Point>& points() noexcept { return _pointProperties._points; }
+
+    const std::vector<Point>& points() const noexcept
     {
         return _pointProperties._points;
     }

--- a/include/morphio/properties.h
+++ b/include/morphio/properties.h
@@ -126,7 +126,7 @@ struct MitochondriaPointLevel
 
     MitochondriaPointLevel() = default;
     MitochondriaPointLevel(const MitochondriaPointLevel& data,
-                           const SectionRange& range);
+        const SectionRange& range);
 
     MitochondriaPointLevel(
         std::vector<uint32_t> sectionId,

--- a/include/morphio/properties.h
+++ b/include/morphio/properties.h
@@ -88,10 +88,10 @@ struct PointLevel
     std::vector<Diameter::Type> _diameters;
     std::vector<Perimeter::Type> _perimeters;
 
-    PointLevel() {}
+    PointLevel() = default;
     PointLevel(std::vector<Point::Type> points,
         std::vector<Diameter::Type> diameters,
-        std::vector<Perimeter::Type> perimeters = std::vector<Perimeter::Type>());
+        std::vector<Perimeter::Type> perimeters = {});
     PointLevel(const PointLevel& data);
     PointLevel(const PointLevel& data, SectionRange range);
     PointLevel& operator=(const PointLevel& other);
@@ -124,9 +124,9 @@ struct MitochondriaPointLevel
     std::vector<MitoPathLength::Type> _relativePathLengths;
     std::vector<MitoDiameter::Type> _diameters;
 
-    MitochondriaPointLevel() {}
+    MitochondriaPointLevel() = default;
     MitochondriaPointLevel(const MitochondriaPointLevel& data,
-                           SectionRange range);
+                           const SectionRange& range);
 
     MitochondriaPointLevel(
         std::vector<uint32_t> sectionId,
@@ -194,46 +194,70 @@ struct Properties
     // Functions
     ////////////////////////////////////////////////////////////////////////////////
     template <typename T>
-    std::vector<typename T::Type>& get();
+    std::vector<typename T::Type>& get() noexcept;
     template <typename T>
-    const std::vector<typename T::Type>& get() const;
+    const std::vector<typename T::Type>& get() const noexcept;
 
-    const morphio::MorphologyVersion& version() { return _cellLevel._version; }
-    const morphio::CellFamily& cellFamily() { return _cellLevel._cellFamily; }
-    const morphio::SomaType& somaType() { return _cellLevel._somaType; }
+    const morphio::MorphologyVersion& version() const noexcept { return _cellLevel._version; }
+    const morphio::CellFamily& cellFamily() const noexcept { return _cellLevel._cellFamily; }
+    const morphio::SomaType& somaType() const noexcept { return _cellLevel._somaType; }
     template <typename T>
-    const std::map<int32_t, std::vector<uint32_t>>& children();
+    const std::map<int32_t, std::vector<uint32_t>>& children() const noexcept;
 };
 
 template <>
-const std::map<int32_t, std::vector<uint32_t>>& Properties::children<Section>();
+const std::map<int32_t, std::vector<uint32_t>>& Properties::children<Section>() const noexcept;
 template <>
 const std::map<int32_t, std::vector<uint32_t>>&
-    Properties::children<MitoSection>();
+    Properties::children<MitoSection>() const noexcept;
 
 std::ostream& operator<<(std::ostream& os, const Properties& properties);
 std::ostream& operator<<(std::ostream& os, const PointLevel& pointLevel);
 
 template <>
-std::vector<Point::Type>& Properties::get<Point>();
+const std::vector<Point::Type>& Properties::get<Point>() const noexcept;
 template <>
-std::vector<Perimeter::Type>& Properties::get<Perimeter>();
+std::vector<Point::Type>& Properties::get<Point>() noexcept;
+
 template <>
-std::vector<Diameter::Type>& Properties::get<Diameter>();
+const std::vector<Perimeter::Type>& Properties::get<Perimeter>() const noexcept;
 template <>
-std::vector<MitoSection::Type>& Properties::get<MitoSection>();
+std::vector<Perimeter::Type>& Properties::get<Perimeter>() noexcept;
+
 template <>
-std::vector<MitoPathLength::Type>& Properties::get<MitoPathLength>();
+const std::vector<Diameter::Type>& Properties::get<Diameter>() const noexcept;
 template <>
-std::vector<MitoNeuriteSectionId::Type>& Properties::get<MitoNeuriteSectionId>();
+std::vector<Diameter::Type>& Properties::get<Diameter>() noexcept;
+
 template <>
-std::vector<MitoDiameter::Type>& Properties::get<MitoDiameter>();
+const std::vector<MitoSection::Type>& Properties::get<MitoSection>() const noexcept;
 template <>
-std::vector<Section::Type>& Properties::get<Section>();
+std::vector<MitoSection::Type>& Properties::get<MitoSection>() noexcept;
+
 template <>
-std::vector<SectionType::Type>& Properties::get<SectionType>();
+const std::vector<MitoPathLength::Type>& Properties::get<MitoPathLength>() const noexcept;
 template <>
-const std::vector<Section::Type>& Properties::get<Section>() const;
+std::vector<MitoPathLength::Type>& Properties::get<MitoPathLength>() noexcept;
+
+template <>
+const std::vector<MitoNeuriteSectionId::Type>& Properties::get<MitoNeuriteSectionId>() const noexcept;
+template <>
+std::vector<MitoNeuriteSectionId::Type>& Properties::get<MitoNeuriteSectionId>() noexcept;
+
+template <>
+const std::vector<MitoDiameter::Type>& Properties::get<MitoDiameter>() const noexcept;
+template <>
+std::vector<MitoDiameter::Type>& Properties::get<MitoDiameter>() noexcept;
+
+template <>
+const std::vector<Section::Type>& Properties::get<Section>() const noexcept;
+template <>
+std::vector<Section::Type>& Properties::get<Section>() noexcept;
+
+template <>
+const std::vector<SectionType::Type>& Properties::get<SectionType>() const noexcept;
+template <>
+std::vector<SectionType::Type>& Properties::get<SectionType>() noexcept;
 
 } // namespace Property
 } // namespace morphio

--- a/include/morphio/section.h
+++ b/include/morphio/section.h
@@ -88,7 +88,7 @@ public:
 
 protected:
     Section(uint32_t id_, const std::shared_ptr<Property::Properties>& properties)
-    : SectionBase(id_, properties)
+        : SectionBase(id_, properties)
     {}
 };
 

--- a/include/morphio/section.h
+++ b/include/morphio/section.h
@@ -62,32 +62,32 @@ public:
     (https://github.com/isocpp/CppCoreGuidelines/blob/master/docs/gsl-intro.md#gslspan-what-is-gslspan-and-what-is-it-for)
      to this section's point coordinates
     **/
-    const range<const Point> points() const;
+    range<const Point> points() const;
 
     /**
      * Return a view
     (https://github.com/isocpp/CppCoreGuidelines/blob/master/docs/gsl-intro.md#gslspan-what-is-gslspan-and-what-is-it-for)
      to this section's point diameters
     **/
-    const range<const float> diameters() const;
+    range<const float> diameters() const;
 
     /**
      * Return a view
      (https://github.com/isocpp/CppCoreGuidelines/blob/master/docs/gsl-intro.md#gslspan-what-is-gslspan-and-what-is-it-for)
      to this section's point perimeters
      **/
-    const range<const float> perimeters() const;
+    range<const float> perimeters() const;
 
     /**
      * Return the morphological type of this section (dendrite, axon, ...)
      */
     SectionType type() const;
     friend class mut::Section;
-    friend Section Morphology::section(const uint32_t&) const;
+    friend Section Morphology::section(uint32_t) const;
     friend class SectionBase<Section>;
 
 protected:
-    Section(uint32_t id_, std::shared_ptr<Property::Properties> properties)
+    Section(uint32_t id_, const std::shared_ptr<Property::Properties>& properties)
     : SectionBase(id_, properties)
     {}
 };
@@ -99,4 +99,4 @@ template class SectionBase<Section>;
 
 std::ostream& operator<<(std::ostream& os, const morphio::Section& section);
 std::ostream& operator<<(std::ostream& os,
-    morphio::range<const morphio::Point> points);
+    const morphio::range<const morphio::Point>& points);

--- a/include/morphio/section_base.h
+++ b/include/morphio/section_base.h
@@ -28,12 +28,12 @@ public:
     : _id(0)
     {}
 
-    explicit SectionBase(const SectionBase& section);
+    SectionBase(const SectionBase& section);
 
-    const SectionBase& operator=(const SectionBase& section);
+    SectionBase& operator=(const SectionBase& other);
 
-    bool operator==(const SectionBase& section) const;
-    bool operator!=(const SectionBase& section) const;
+    bool operator==(const SectionBase& other) const;
+    bool operator!=(const SectionBase& other) const;
 
     /**
      * Return true if this section is a root section (parent ID == -1)
@@ -50,15 +50,15 @@ public:
     /**
      * Return a list of children sections
      */
-    const std::vector<T> children() const;
+    std::vector<T> children() const;
 
     /** Return the ID of this section. */
     uint32_t id() const;
 
 protected:
-    SectionBase(uint32_t id, std::shared_ptr<Property::Properties> properties);
+    SectionBase(uint32_t id, const std::shared_ptr<Property::Properties>& properties);
     template <typename Property>
-    const range<const typename Property::Type> get() const;
+    range<const typename Property::Type> get() const;
 
     uint32_t _id;
     SectionRange _range;
@@ -69,6 +69,6 @@ protected:
 
 std::ostream& operator<<(std::ostream& os, const morphio::Section& section);
 std::ostream& operator<<(std::ostream& os,
-    morphio::range<const morphio::Point> points);
+    const morphio::range<const morphio::Point>& points);
 
 #include "section_base.tpp"

--- a/include/morphio/section_base.h
+++ b/include/morphio/section_base.h
@@ -32,8 +32,8 @@ public:
 
     SectionBase& operator=(const SectionBase& other);
 
-    bool operator==(const SectionBase& other) const;
-    bool operator!=(const SectionBase& other) const;
+    inline bool operator==(const SectionBase& other) const noexcept;
+    inline bool operator!=(const SectionBase& other) const noexcept;
 
     /**
      * Return true if this section is a root section (parent ID == -1)
@@ -53,7 +53,7 @@ public:
     std::vector<T> children() const;
 
     /** Return the ID of this section. */
-    uint32_t id() const;
+    inline uint32_t id() const noexcept;
 
 protected:
     SectionBase(uint32_t id, const std::shared_ptr<Property::Properties>& properties);
@@ -64,6 +64,24 @@ protected:
     SectionRange _range;
     std::shared_ptr<Property::Properties> _properties;
 };
+
+template <typename T>
+inline bool SectionBase<T>::operator==(const SectionBase& other) const noexcept
+{
+    return other._id == _id && other._properties == _properties;
+}
+
+template <typename T>
+inline bool SectionBase<T>::operator!=(const SectionBase& other) const noexcept
+{
+    return !(*this == other);
+}
+
+template <typename T>
+inline uint32_t SectionBase<T>::id() const noexcept
+{
+    return _id;
+}
 
 } // namespace morphio
 

--- a/include/morphio/section_base.tpp
+++ b/include/morphio/section_base.tpp
@@ -46,24 +46,6 @@ SectionBase<T>& SectionBase<T>::operator=(const SectionBase& section)
 }
 
 template <typename T>
-bool SectionBase<T>::operator==(const SectionBase& other) const
-{
-    return other._id == _id && other._properties == _properties;
-}
-
-template <typename T>
-bool SectionBase<T>::operator!=(const SectionBase& other) const
-{
-    return !(*this == other);
-}
-
-template <typename T>
-uint32_t SectionBase<T>::id() const
-{
-    return _id;
-}
-
-template <typename T>
 template <typename TProperty>
 range<const typename TProperty::Type> SectionBase<T>::get() const
 {

--- a/include/morphio/section_iterators.hpp
+++ b/include/morphio/section_iterators.hpp
@@ -57,9 +57,15 @@ std::shared_ptr<SectionT> getParent(const std::shared_ptr<SectionT>& current)
 namespace morphio {
 
 template <typename SectionT, typename MorphologyT>
-class breadth_iterator_t : public std::iterator<std::input_iterator_tag, const SectionT>
+class breadth_iterator_t
 {
 public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = SectionT;
+    using difference_type = std::ptrdiff_t;
+    using pointer = SectionT*;
+    using reference = SectionT&;
+
     breadth_iterator_t() = default;
 
     explicit breadth_iterator_t(const SectionT& section)
@@ -117,9 +123,15 @@ private:
 };
 
 template <typename SectionT, typename MorphologyT>
-class depth_iterator_t : public std::iterator<std::input_iterator_tag, const SectionT>
+class depth_iterator_t
 {
 public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = SectionT;
+    using difference_type = std::ptrdiff_t;
+    using pointer = SectionT*;
+    using reference = SectionT&;
+
     depth_iterator_t() = default;
 
     explicit depth_iterator_t(const SectionT& section)
@@ -177,9 +189,15 @@ private:
 };
 
 template <typename SectionT>
-class upstream_iterator_t : public std::iterator<std::input_iterator_tag, const SectionT>
+class upstream_iterator_t
 {
 public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = SectionT;
+    using difference_type = std::ptrdiff_t;
+    using pointer = SectionT*;
+    using reference = SectionT&;
+
     upstream_iterator_t()
     : unused(0)
     , end(true)

--- a/include/morphio/section_iterators.hpp
+++ b/include/morphio/section_iterators.hpp
@@ -12,7 +12,7 @@
 namespace detail {
 
 template<typename SectionT, typename MorphologyT>
-std::vector<SectionT> getChildren(const MorphologyT& morphology)
+std::vector<SectionT> getChildren(const MorphologyT& morphology) noexcept
 {
     return morphology.rootSections();
 }
@@ -57,7 +57,7 @@ std::shared_ptr<SectionT> getParent(const std::shared_ptr<SectionT>& current)
 namespace morphio {
 
 template<typename SectionT, typename MorphologyT>
-class breadth_iterator_t {
+class breadth_iterator_t: public std::iterator<std::input_iterator_tag, const SectionT> {
 public:
     breadth_iterator_t() = default;
 
@@ -76,18 +76,18 @@ public:
     : deque_(other.deque_)
     {}
 
-    SectionT operator*() const
+    const SectionT& operator*() const
     {
         return deque_.front();
     }
 
-    breadth_iterator_t operator++()
+    breadth_iterator_t& operator++()
     {
         if (deque_.empty()) {
             LBTHROW(MorphioError("Can't iterate past the end"));
         }
 
-        const auto children = detail::getChildren(deque_.front());
+        const auto& children = detail::getChildren(deque_.front());
         deque_.pop_front();
         std::copy(children.begin(), children.end(), std::back_inserter(deque_));
 
@@ -116,7 +116,7 @@ private:
 };
 
 template<typename SectionT, typename MorphologyT>
-class depth_iterator_t {
+class depth_iterator_t: public std::iterator<std::input_iterator_tag, const SectionT> {
 public:
     depth_iterator_t() = default;
 
@@ -135,12 +135,12 @@ public:
     : deque_(other.deque_)
     {}
 
-    SectionT operator*() const
+    const SectionT& operator*() const
     {
         return deque_.front();
     }
 
-    depth_iterator_t operator++()
+    depth_iterator_t& operator++()
     {
         if (deque_.empty()) {
             LBTHROW(MorphioError("Can't iterate past the end"));
@@ -175,7 +175,7 @@ private:
 };
 
 template<typename SectionT>
-class upstream_iterator_t {
+class upstream_iterator_t: public std::iterator<std::input_iterator_tag, const SectionT> {
 public:
     upstream_iterator_t()
     : unused(0)
@@ -202,12 +202,12 @@ public:
         }
     }
 
-    SectionT operator*() const
+    const SectionT& operator*() const
     {
         return current;
     }
 
-    upstream_iterator_t operator++()
+    upstream_iterator_t& operator++()
     {
         if (end) {
             LBTHROW(MissingParentError("Cannot call iterate upstream past the root node"));

--- a/include/morphio/section_iterators.hpp
+++ b/include/morphio/section_iterators.hpp
@@ -11,7 +11,7 @@
 
 namespace detail {
 
-template<typename SectionT, typename MorphologyT>
+template <typename SectionT, typename MorphologyT>
 std::vector<SectionT> getChildren(const MorphologyT& morphology) noexcept
 {
     return morphology.rootSections();
@@ -56,8 +56,9 @@ std::shared_ptr<SectionT> getParent(const std::shared_ptr<SectionT>& current)
 
 namespace morphio {
 
-template<typename SectionT, typename MorphologyT>
-class breadth_iterator_t: public std::iterator<std::input_iterator_tag, const SectionT> {
+template <typename SectionT, typename MorphologyT>
+class breadth_iterator_t : public std::iterator<std::input_iterator_tag, const SectionT>
+{
 public:
     breadth_iterator_t() = default;
 
@@ -115,8 +116,9 @@ private:
     std::deque<SectionT> deque_;
 };
 
-template<typename SectionT, typename MorphologyT>
-class depth_iterator_t: public std::iterator<std::input_iterator_tag, const SectionT> {
+template <typename SectionT, typename MorphologyT>
+class depth_iterator_t : public std::iterator<std::input_iterator_tag, const SectionT>
+{
 public:
     depth_iterator_t() = default;
 
@@ -174,8 +176,9 @@ private:
     std::deque<SectionT> deque_;
 };
 
-template<typename SectionT>
-class upstream_iterator_t: public std::iterator<std::input_iterator_tag, const SectionT> {
+template <typename SectionT>
+class upstream_iterator_t : public std::iterator<std::input_iterator_tag, const SectionT>
+{
 public:
     upstream_iterator_t()
     : unused(0)

--- a/include/morphio/section_iterators.hpp
+++ b/include/morphio/section_iterators.hpp
@@ -68,55 +68,17 @@ public:
 
     breadth_iterator_t() = default;
 
-    explicit breadth_iterator_t(const SectionT& section)
-    {
-        deque_.push_front(section);
-    }
+    inline explicit breadth_iterator_t(const SectionT& section);
+    inline explicit breadth_iterator_t(const MorphologyT& morphology);
+    inline breadth_iterator_t(const breadth_iterator_t& other);
 
-    explicit breadth_iterator_t(const MorphologyT& morphology)
-    {
-        const auto& children = detail::getChildren<SectionT, MorphologyT>(morphology);
-        std::copy(children.begin(), children.end(), std::back_inserter(deque_));
-    }
+    inline const SectionT& operator*() const;
 
-    breadth_iterator_t(const breadth_iterator_t& other)
-    : deque_(other.deque_)
-    {}
+    inline breadth_iterator_t& operator++();
+    inline breadth_iterator_t operator++(int);
 
-    const SectionT& operator*() const
-    {
-        return deque_.front();
-    }
-
-    breadth_iterator_t& operator++()
-    {
-        if (deque_.empty()) {
-            LBTHROW(MorphioError("Can't iterate past the end"));
-        }
-
-        const auto& children = detail::getChildren(deque_.front());
-        deque_.pop_front();
-        std::copy(children.begin(), children.end(), std::back_inserter(deque_));
-
-        return *this;
-    }
-
-    breadth_iterator_t operator++(int)
-    {
-        breadth_iterator_t ret(*this);
-        ++(*this);
-        return ret;
-    }
-
-    bool operator==(const breadth_iterator_t& other) const
-    {
-        return deque_ == other.deque_;
-    }
-
-    bool operator!=(const breadth_iterator_t& other) const
-    {
-        return !(*this == other);
-    }
+    inline bool operator==(const breadth_iterator_t& other) const;
+    bool operator!=(const breadth_iterator_t& other) const;
 
 private:
     std::deque<SectionT> deque_;
@@ -134,55 +96,17 @@ public:
 
     depth_iterator_t() = default;
 
-    explicit depth_iterator_t(const SectionT& section)
-    {
-        deque_.push_front(section);
-    }
+    inline explicit depth_iterator_t(const SectionT& section);
+    inline explicit depth_iterator_t(const MorphologyT& morphology);
+    inline depth_iterator_t(const depth_iterator_t& other);
 
-    explicit depth_iterator_t(const MorphologyT& morphology)
-    {
-        const auto& children = detail::getChildren<SectionT, MorphologyT>(morphology);
-        std::copy(children.rbegin(), children.rend(), std::front_inserter(deque_));
-    }
+    inline const SectionT& operator*() const;
 
-    depth_iterator_t(const depth_iterator_t& other)
-    : deque_(other.deque_)
-    {}
+    inline depth_iterator_t& operator++();
+    inline depth_iterator_t operator++(int);
 
-    const SectionT& operator*() const
-    {
-        return deque_.front();
-    }
-
-    depth_iterator_t& operator++()
-    {
-        if (deque_.empty()) {
-            LBTHROW(MorphioError("Can't iterate past the end"));
-        }
-
-        const auto children = detail::getChildren(deque_.front());
-        deque_.pop_front();
-        std::copy(children.rbegin(), children.rend(), std::front_inserter(deque_));
-
-        return *this;
-    }
-
-    depth_iterator_t operator++(int)
-    {
-        depth_iterator_t ret(*this);
-        ++(*this);
-        return ret;
-    }
-
-    bool operator==(const depth_iterator_t& other) const
-    {
-        return deque_ == other.deque_;
-    }
-
-    bool operator!=(const depth_iterator_t& other) const
-    {
-        return !(*this == other);
-    }
+    inline bool operator==(const depth_iterator_t& other) const;
+    inline bool operator!=(const depth_iterator_t& other) const;
 
 private:
     std::deque<SectionT> deque_;
@@ -198,68 +122,18 @@ public:
     using pointer = SectionT*;
     using reference = SectionT&;
 
-    upstream_iterator_t()
-    : unused(0)
-    , end(true)
-    { }
+    inline upstream_iterator_t();
+    inline explicit upstream_iterator_t(const SectionT& section);
+    inline upstream_iterator_t(const upstream_iterator_t& other);
+    inline ~upstream_iterator_t();
 
-    explicit upstream_iterator_t(const SectionT& section)
-    : current(section)
-    , end(false)
-    { }
+    inline const SectionT& operator*() const;
 
-    upstream_iterator_t(const upstream_iterator_t& other)
-    {
-        end = other.end;
-        if (!other.end) {
-            new (&current) SectionT(other.current);
-        }
-    }
+    inline upstream_iterator_t& operator++();
+    inline upstream_iterator_t operator++(int);
 
-    ~upstream_iterator_t()
-    {
-        if (!end) {
-            this->current.~SectionT();
-        }
-    }
-
-    const SectionT& operator*() const
-    {
-        return current;
-    }
-
-    upstream_iterator_t& operator++()
-    {
-        if (end) {
-            LBTHROW(MissingParentError("Cannot call iterate upstream past the root node"));
-        } else if (detail::isRoot(current)) {
-            end = true;
-            this->current.~SectionT();
-        } else {
-            current = detail::getParent(current);
-        }
-        return *this;
-    }
-
-    upstream_iterator_t operator++(int)
-    {
-        upstream_iterator_t ret(*this);
-        ++(*this);
-        return ret;
-    }
-
-    bool operator==(const upstream_iterator_t& other) const
-    {
-        if (end) {
-            return end == other.end;
-        }
-        return current == other.current;
-    }
-
-    bool operator!=(const upstream_iterator_t& other) const
-    {
-        return !(*this == other);
-    }
+    inline bool operator==(const upstream_iterator_t& other) const;
+    inline bool operator!=(const upstream_iterator_t& other) const;
 
 private:
     // This is a workaround for not having std::optional until c++17.
@@ -267,11 +141,210 @@ private:
     // on the fly, so we'd have to heap allocate; however, to signal the end()
     // of iteration, we need a 'default' section or a sentinel.  Since the concept
     // of a default section is nebulous, a sentinel was used instead.
-    union {
+    union
+    {
         char unused;
         SectionT current;
     };
     bool end;
 };
+
+// breath_iterator_t class definition
+
+template <typename SectionT, typename MorphologyT>
+inline breadth_iterator_t<SectionT, MorphologyT>::breadth_iterator_t(const SectionT& section)
+{
+    deque_.push_front(section);
+}
+
+template <typename SectionT, typename MorphologyT>
+inline breadth_iterator_t<SectionT, MorphologyT>::breadth_iterator_t(const MorphologyT& morphology)
+{
+    const auto& children = detail::getChildren<SectionT, MorphologyT>(morphology);
+    std::copy(children.begin(), children.end(), std::back_inserter(deque_));
+}
+
+template <typename SectionT, typename MorphologyT>
+inline breadth_iterator_t<SectionT, MorphologyT>::breadth_iterator_t(const breadth_iterator_t& other)
+    : deque_(other.deque_)
+{
+}
+
+template <typename SectionT, typename MorphologyT>
+inline const SectionT& breadth_iterator_t<SectionT, MorphologyT>::operator*() const
+{
+    return deque_.front();
+}
+
+template <typename SectionT, typename MorphologyT>
+inline breadth_iterator_t<SectionT, MorphologyT>& breadth_iterator_t<SectionT, MorphologyT>::operator++()
+{
+    if (deque_.empty()) {
+        LBTHROW(MorphioError("Can't iterate past the end"));
+    }
+
+    const auto& children = detail::getChildren(deque_.front());
+    deque_.pop_front();
+    std::copy(children.begin(), children.end(), std::back_inserter(deque_));
+
+    return *this;
+}
+
+template <typename SectionT, typename MorphologyT>
+inline breadth_iterator_t<SectionT, MorphologyT> breadth_iterator_t<SectionT, MorphologyT>::operator++(int)
+{
+    breadth_iterator_t ret(*this);
+    ++(*this);
+    return ret;
+}
+
+template <typename SectionT, typename MorphologyT>
+inline bool breadth_iterator_t<SectionT, MorphologyT>::operator==(const breadth_iterator_t& other) const
+{
+    return deque_ == other.deque_;
+}
+
+template <typename SectionT, typename MorphologyT>
+inline bool breadth_iterator_t<SectionT, MorphologyT>::operator!=(const breadth_iterator_t& other) const
+{
+    return !(*this == other);
+}
+
+// depth_iterator_t class definition
+
+template <typename SectionT, typename MorphologyT>
+inline depth_iterator_t<SectionT, MorphologyT>::depth_iterator_t(const SectionT& section)
+{
+    deque_.push_front(section);
+}
+
+template <typename SectionT, typename MorphologyT>
+inline depth_iterator_t<SectionT, MorphologyT>::depth_iterator_t(const MorphologyT& morphology)
+{
+    const auto& children = detail::getChildren<SectionT, MorphologyT>(morphology);
+    std::copy(children.rbegin(), children.rend(), std::front_inserter(deque_));
+}
+
+template <typename SectionT, typename MorphologyT>
+inline depth_iterator_t<SectionT, MorphologyT>::depth_iterator_t(const depth_iterator_t& other)
+    : deque_(other.deque_)
+{
+}
+
+template <typename SectionT, typename MorphologyT>
+inline const SectionT& depth_iterator_t<SectionT, MorphologyT>::operator*() const
+{
+    return deque_.front();
+}
+
+template <typename SectionT, typename MorphologyT>
+inline depth_iterator_t<SectionT, MorphologyT>& depth_iterator_t<SectionT, MorphologyT>::operator++()
+{
+    if (deque_.empty()) {
+        LBTHROW(MorphioError("Can't iterate past the end"));
+    }
+
+    const auto children = detail::getChildren(deque_.front());
+    deque_.pop_front();
+    std::copy(children.rbegin(), children.rend(), std::front_inserter(deque_));
+
+    return *this;
+}
+
+template <typename SectionT, typename MorphologyT>
+inline depth_iterator_t<SectionT, MorphologyT> depth_iterator_t<SectionT, MorphologyT>::operator++(int)
+{
+    depth_iterator_t ret(*this);
+    ++(*this);
+    return ret;
+}
+
+template <typename SectionT, typename MorphologyT>
+inline bool depth_iterator_t<SectionT, MorphologyT>::operator==(const depth_iterator_t& other) const
+{
+    return deque_ == other.deque_;
+}
+
+template <typename SectionT, typename MorphologyT>
+inline bool depth_iterator_t<SectionT, MorphologyT>::operator!=(const depth_iterator_t& other) const
+{
+    return !(*this == other);
+}
+
+// upstream_iterator_t class definition
+
+template <typename SectionT>
+inline upstream_iterator_t<SectionT>::upstream_iterator_t()
+    : unused(0)
+    , end(true)
+{
+}
+
+template <typename SectionT>
+inline upstream_iterator_t<SectionT>::upstream_iterator_t(const SectionT& section)
+    : current(section)
+    , end(false)
+{
+}
+
+template <typename SectionT>
+inline upstream_iterator_t<SectionT>::upstream_iterator_t(const upstream_iterator_t& other)
+{
+    end = other.end;
+    if (!other.end) {
+        new (&current) SectionT(other.current);
+    }
+}
+
+template <typename SectionT>
+inline upstream_iterator_t<SectionT>::~upstream_iterator_t()
+{
+    if (!end) {
+        this->current.~SectionT();
+    }
+}
+
+template <typename SectionT>
+inline const SectionT& upstream_iterator_t<SectionT>::operator*() const
+{
+    return current;
+}
+
+template <typename SectionT>
+inline upstream_iterator_t<SectionT>& upstream_iterator_t<SectionT>::operator++()
+{
+    if (end) {
+        LBTHROW(MissingParentError("Cannot call iterate upstream past the root node"));
+    } else if (detail::isRoot(current)) {
+        end = true;
+        this->current.~SectionT();
+    } else {
+        current = detail::getParent(current);
+    }
+    return *this;
+}
+
+template <typename SectionT>
+inline upstream_iterator_t<SectionT> upstream_iterator_t<SectionT>::operator++(int)
+{
+    upstream_iterator_t ret(*this);
+    ++(*this);
+    return ret;
+}
+
+template <typename SectionT>
+inline bool upstream_iterator_t<SectionT>::operator==(const upstream_iterator_t& other) const
+{
+    if (end) {
+        return end == other.end;
+    }
+    return current == other.current;
+}
+
+template <typename SectionT>
+inline bool upstream_iterator_t<SectionT>::operator!=(const upstream_iterator_t& other) const
+{
+    return !(*this == other);
+}
 
 } // namespace morphio

--- a/include/morphio/shared_utils.tpp
+++ b/include/morphio/shared_utils.tpp
@@ -59,10 +59,10 @@ std::vector<typename T::Type> copySpan(
     const std::vector<typename T::Type>& data, SectionRange range)
 {
     if (data.empty())
-        return std::vector<typename T::Type>();
+        return {};
 
-    return std::vector<typename T::Type>(data.begin() + static_cast<long int>(range.first),
-        data.begin() + static_cast<long int>(range.second));
+    return {data.begin() + static_cast<long int>(range.first),
+        data.begin() + static_cast<long int>(range.second)};
 }
 
 } // namespace morphio

--- a/include/morphio/soma.h
+++ b/include/morphio/soma.h
@@ -31,23 +31,17 @@ public:
     /**
      * Return the  coordinates (x,y,z) of all soma points
      **/
-    range<const Point> points() const noexcept
-    {
-        return _properties->_somaLevel._points;
-    }
+    inline range<const Point> points() const noexcept;
 
     /**
      * Return the diameters of all soma points
      **/
-    range<const float> diameters() const noexcept
-    {
-        return _properties->_somaLevel._diameters;
-    }
+    inline range<const float> diameters() const noexcept;
 
     /**
      * Return the soma type
      **/
-    SomaType type() const noexcept { return _properties->_cellLevel._somaType; }
+    inline SomaType type() const noexcept;
     /**
      * Return the center of gravity of the soma points
      **/
@@ -82,4 +76,20 @@ private:
 
     std::shared_ptr<Property::Properties> _properties;
 };
+
+inline range<const Point> Soma::points() const noexcept
+{
+    return _properties->_somaLevel._points;
+}
+
+inline range<const float> Soma::diameters() const noexcept
+{
+    return _properties->_somaLevel._diameters;
+}
+
+inline SomaType Soma::type() const noexcept
+{
+    return _properties->_cellLevel._somaType;
+}
+
 } // namespace morphio

--- a/include/morphio/soma.h
+++ b/include/morphio/soma.h
@@ -31,7 +31,7 @@ public:
     /**
      * Return the  coordinates (x,y,z) of all soma points
      **/
-    const range<const Point> points() const
+    range<const Point> points() const noexcept
     {
         return _properties->_somaLevel._points;
     }
@@ -39,7 +39,7 @@ public:
     /**
      * Return the diameters of all soma points
      **/
-    const range<const float> diameters() const
+    range<const float> diameters() const noexcept
     {
         return _properties->_somaLevel._diameters;
     }
@@ -47,11 +47,11 @@ public:
     /**
      * Return the soma type
      **/
-    SomaType type() const { return _properties->_cellLevel._somaType; }
+    SomaType type() const noexcept { return _properties->_cellLevel._somaType; }
     /**
      * Return the center of gravity of the soma points
      **/
-    const Point center() const;
+    Point center() const;
 
     /**
      * Return the soma volume\n"
@@ -72,7 +72,7 @@ public:
     float maxDistance() const;
 
 private:
-    Soma(std::shared_ptr<Property::Properties>);
+    explicit Soma(const std::shared_ptr<Property::Properties>&);
     // TODO: find out why the following line does not work
     // when friend class Morphology; is removed
     // template <typename Property>

--- a/include/morphio/vasc/iterators.hpp
+++ b/include/morphio/vasc/iterators.hpp
@@ -7,12 +7,17 @@ namespace morphio {
 namespace vasculature {
 
 template <typename SectionT, typename VasculatureT>
-class graph_iterator_t : public std::iterator<std::input_iterator_tag, SectionT>
+class graph_iterator_t
 {
     std::set<SectionT> visited;
     std::stack<SectionT> container;
 
 public:
+using iterator_category = std::input_iterator_tag;
+using value_type = SectionT;
+using difference_type = std::ptrdiff_t;
+using pointer = SectionT*;
+using reference = SectionT&;
 graph_iterator_t() = default;
 
 explicit graph_iterator_t(const SectionT& vasculatureSection)

--- a/include/morphio/vasc/iterators.hpp
+++ b/include/morphio/vasc/iterators.hpp
@@ -1,4 +1,5 @@
 
+#include <iterator>
 #include <set>
 #include <stack>
 
@@ -6,7 +7,7 @@ namespace morphio {
 namespace vasculature {
 
 template<typename SectionT, typename VasculatureT>
-class graph_iterator_t
+class graph_iterator_t: public std::iterator<std::input_iterator_tag, SectionT>
 {
     std::set<SectionT> visited;
     std::stack<SectionT> container;
@@ -21,7 +22,7 @@ explicit graph_iterator_t(const SectionT& vasculatureSection)
 
 explicit graph_iterator_t(const VasculatureT& vasculatureMorphology)
 {
-    auto sections = vasculatureMorphology.sections();
+    const auto& sections = vasculatureMorphology.sections();
     for (std::size_t i = 0; i < sections.size(); ++i) {
         if (sections[i].predecessors().empty()) {
             container.push(sections[i]);
@@ -40,7 +41,7 @@ bool operator!=(const graph_iterator_t& other) const
     return !(*this == other);
 }
 
-SectionT operator*() const
+const SectionT& operator*() const
 {
     return container.top();
 }
@@ -49,7 +50,7 @@ graph_iterator_t& operator++()
 {
     const auto& section = *(*this);
     container.pop();
-    auto& neighbors = section.neighbors();
+    const auto& neighbors = section.neighbors();
     for (auto it = neighbors.rbegin(); it != neighbors.rend(); ++it)
         if (visited.find(*it) == visited.end()) {
             container.push(*it);
@@ -57,6 +58,7 @@ graph_iterator_t& operator++()
         }
     return *this;
 }
+
 graph_iterator_t operator++(int)
 {
     graph_iterator_t retval = *this;

--- a/include/morphio/vasc/iterators.hpp
+++ b/include/morphio/vasc/iterators.hpp
@@ -13,19 +13,31 @@ class graph_iterator_t
     std::stack<SectionT> container;
 
 public:
-using iterator_category = std::input_iterator_tag;
-using value_type = SectionT;
-using difference_type = std::ptrdiff_t;
-using pointer = SectionT*;
-using reference = SectionT&;
-graph_iterator_t() = default;
+    using iterator_category = std::input_iterator_tag;
+    using value_type = SectionT;
+    using difference_type = std::ptrdiff_t;
+    using pointer = SectionT*;
+    using reference = SectionT&;
+    graph_iterator_t() = default;
+    inline explicit graph_iterator_t(const SectionT& vasculatureSection);
+    inline explicit graph_iterator_t(const VasculatureT& vasculatureMorphology);
 
-explicit graph_iterator_t(const SectionT& vasculatureSection)
+    inline bool operator==(const graph_iterator_t& other) const;
+    inline bool operator!=(const graph_iterator_t& other) const;
+    inline const SectionT& operator*() const;
+
+    inline graph_iterator_t& operator++();
+    inline graph_iterator_t operator++(int);
+};
+
+template <typename SectionT, typename VasculatureT>
+inline graph_iterator_t<SectionT, VasculatureT>::graph_iterator_t(const SectionT& vasculatureSection)
 {
     container.push(vasculatureSection);
 }
 
-explicit graph_iterator_t(const VasculatureT& vasculatureMorphology)
+template <typename SectionT, typename VasculatureT>
+inline graph_iterator_t<SectionT, VasculatureT>::graph_iterator_t(const VasculatureT& vasculatureMorphology)
 {
     const auto& sections = vasculatureMorphology.sections();
     for (std::size_t i = 0; i < sections.size(); ++i) {
@@ -36,22 +48,27 @@ explicit graph_iterator_t(const VasculatureT& vasculatureMorphology)
     }
 }
 
-bool operator==(const graph_iterator_t& other) const
+template <typename SectionT, typename VasculatureT>
+inline bool graph_iterator_t<SectionT, VasculatureT>::operator==(const graph_iterator_t& other) const
 {
     return container == other.container;
 }
 
-bool operator!=(const graph_iterator_t& other) const
+template <typename SectionT, typename VasculatureT>
+inline bool graph_iterator_t<SectionT, VasculatureT>::operator!=(const graph_iterator_t& other) const
 {
     return !(*this == other);
 }
 
-const SectionT& operator*() const
+template <typename SectionT, typename VasculatureT>
+inline const SectionT& graph_iterator_t<SectionT, VasculatureT>::operator*() const
 {
     return container.top();
 }
 
-graph_iterator_t& operator++()
+template <typename SectionT, typename VasculatureT>
+inline graph_iterator_t<SectionT, VasculatureT>&
+    graph_iterator_t<SectionT, VasculatureT>::operator++()
 {
     const auto& section = *(*this);
     container.pop();
@@ -64,12 +81,14 @@ graph_iterator_t& operator++()
     return *this;
 }
 
-graph_iterator_t operator++(int)
+template <typename SectionT, typename VasculatureT>
+inline graph_iterator_t<SectionT, VasculatureT>
+    graph_iterator_t<SectionT, VasculatureT>::operator++(int)
 {
     graph_iterator_t retval = *this;
     ++(*this);
     return retval;
 }
-};
-}  // namespace vasculature
-}  // namespace morphio
+
+} // namespace vasculature
+} // namespace morphio

--- a/include/morphio/vasc/iterators.hpp
+++ b/include/morphio/vasc/iterators.hpp
@@ -6,8 +6,8 @@
 namespace morphio {
 namespace vasculature {
 
-template<typename SectionT, typename VasculatureT>
-class graph_iterator_t: public std::iterator<std::input_iterator_tag, SectionT>
+template <typename SectionT, typename VasculatureT>
+class graph_iterator_t : public std::iterator<std::input_iterator_tag, SectionT>
 {
     std::set<SectionT> visited;
     std::stack<SectionT> container;

--- a/include/morphio/vasc/properties.h
+++ b/include/morphio/vasc/properties.h
@@ -82,10 +82,12 @@ struct Properties
     template <typename T>
     const std::vector<typename T::Type>& get() const noexcept;
 
-    const std::map<uint32_t, std::vector<uint32_t>>& predecessors() const noexcept {
+    const std::map<uint32_t, std::vector<uint32_t>>& predecessors() const noexcept
+    {
         return _sectionLevel._predecessors;
     }
-    const std::map<uint32_t, std::vector<uint32_t>>& successors() const noexcept {
+    const std::map<uint32_t, std::vector<uint32_t>>& successors() const noexcept
+    {
         return _sectionLevel._successors;
     }
 

--- a/include/morphio/vasc/properties.h
+++ b/include/morphio/vasc/properties.h
@@ -82,19 +82,21 @@ struct Properties
     template <typename T>
     const std::vector<typename T::Type>& get() const noexcept;
 
-    const std::map<uint32_t, std::vector<uint32_t>>& predecessors() const noexcept
-    {
-        return _sectionLevel._predecessors;
-    }
-    const std::map<uint32_t, std::vector<uint32_t>>& successors() const noexcept
-    {
-        return _sectionLevel._successors;
-    }
+    inline const std::map<uint32_t, std::vector<uint32_t>>& predecessors() const noexcept;
+    inline const std::map<uint32_t, std::vector<uint32_t>>& successors() const noexcept;
 
     bool operator==(const Properties& other) const;
     bool operator!=(const Properties& other) const;
 };
 
+inline const std::map<uint32_t, std::vector<uint32_t>>& Properties::predecessors() const noexcept
+{
+    return _sectionLevel._predecessors;
+    }
+    inline const std::map<uint32_t, std::vector<uint32_t>>& Properties::successors() const noexcept
+    {
+        return _sectionLevel._successors;
+    }
 
 std::ostream& operator<<(std::ostream& os, const Properties& properties);
 std::ostream& operator<<(std::ostream& os, const VascPointLevel& pointLevel);

--- a/include/morphio/vasc/properties.h
+++ b/include/morphio/vasc/properties.h
@@ -44,9 +44,9 @@ struct VascPointLevel
     std::vector<Point::Type> _points;
     std::vector<Diameter::Type> _diameters;
 
-    VascPointLevel() {}
-    VascPointLevel(std::vector<Point::Type> points,
-        std::vector<Diameter::Type> diameters);
+    VascPointLevel() = default;
+    VascPointLevel(const std::vector<Point::Type>& points,
+        const std::vector<Diameter::Type>& diameters);
     VascPointLevel(const VascPointLevel& data);
     VascPointLevel(const VascPointLevel& data, SectionRange range);
     VascPointLevel& operator=(const VascPointLevel&) = default;
@@ -77,13 +77,17 @@ struct Properties
     std::vector<Connection::Type> _connectivity;
 
     template <typename T>
-    std::vector<typename T::Type>& get();
+    std::vector<typename T::Type>& get() noexcept;
 
     template <typename T>
-    const std::vector<typename T::Type>& get() const;
+    const std::vector<typename T::Type>& get() const noexcept;
 
-    const std::map<uint32_t, std::vector<uint32_t>>& predecessors();
-    const std::map<uint32_t, std::vector<uint32_t>>& successors();
+    const std::map<uint32_t, std::vector<uint32_t>>& predecessors() const noexcept {
+        return _sectionLevel._predecessors;
+    }
+    const std::map<uint32_t, std::vector<uint32_t>>& successors() const noexcept {
+        return _sectionLevel._successors;
+    }
 
     bool operator==(const Properties& other) const;
     bool operator!=(const Properties& other) const;
@@ -94,17 +98,17 @@ std::ostream& operator<<(std::ostream& os, const Properties& properties);
 std::ostream& operator<<(std::ostream& os, const VascPointLevel& pointLevel);
 
 template <>
-std::vector<Point::Type>& Properties::get<Point>();
+std::vector<Point::Type>& Properties::get<Point>() noexcept;
 template <>
-std::vector<Diameter::Type>& Properties::get<Diameter>();
+std::vector<Diameter::Type>& Properties::get<Diameter>() noexcept;
 template <>
-std::vector<SectionType::Type>& Properties::get<SectionType>();
+std::vector<SectionType::Type>& Properties::get<SectionType>() noexcept;
 template <>
-std::vector<VascSection::Type>& Properties::get<VascSection>();
+std::vector<VascSection::Type>& Properties::get<VascSection>() noexcept;
 template <>
-const std::vector<VascSection::Type>& Properties::get<VascSection>() const;
+const std::vector<VascSection::Type>& Properties::get<VascSection>() const noexcept;
 template <>
-std::vector<Connection::Type>& Properties::get<Connection>();
+std::vector<Connection::Type>& Properties::get<Connection>() noexcept;
 
 } // namespace property
 } // namespace vasculature

--- a/include/morphio/vasc/section.h
+++ b/include/morphio/vasc/section.h
@@ -40,7 +40,7 @@ public:
     std::vector<Section> neighbors() const;
 
     /** Return the ID of this section. */
-    uint32_t id() const;
+    uint32_t id() const noexcept;
 
     /**
        Euclidian distance between first and last point of the section

--- a/include/morphio/vasc/section.h
+++ b/include/morphio/vasc/section.h
@@ -14,11 +14,11 @@ class Section
     using PointAttribute = property::Point;
 
 public:
-    Section(const Section& section);
+    Section(const Section& section) = default;
 
-    const Section& operator=(const Section& section);
+    Section& operator=(const Section& section);
 
-    Section(uint32_t id, std::shared_ptr<property::Properties> morphology);
+    Section(uint32_t id, const std::shared_ptr<property::Properties>& morphology);
 
     bool operator==(const Section& section) const;
     bool operator!=(const Section& section) const;
@@ -27,17 +27,17 @@ public:
     /**
        Returns a list of predecessors or parents of the section
     **/
-    const std::vector<Section> predecessors() const;
+    std::vector<Section> predecessors() const;
 
     /**
        Returns a list of successors or children of the section
     **/
-    const std::vector<Section> successors() const;
+    std::vector<Section> successors() const;
 
     /**
        Returns a list of all neighbors of the section
     **/
-    const std::vector<Section> neighbors() const;
+    std::vector<Section> neighbors() const;
 
     /** Return the ID of this section. */
     uint32_t id() const;
@@ -55,14 +55,14 @@ public:
    (https://github.com/isocpp/CppCoreGuidelines/blob/master/docs/gsl-intro.md#gslspan-what-is-gslspan-and-what-is-it-for)
     to this section's point coordinates
    **/
-    const range<const Point> points() const;
+    range<const Point> points() const;
 
     /**
     * Return a view
    (https://github.com/isocpp/CppCoreGuidelines/blob/master/docs/gsl-intro.md#gslspan-what-is-gslspan-and-what-is-it-for)
     to this section's point diameters
    **/
-    const range<const float> diameters() const;
+    range<const float> diameters() const;
 
     /**
      * Return the morphological type of this section (artery, vein, capillary, ...)
@@ -71,13 +71,15 @@ public:
 
 protected:
     template <typename Property>
-    const range<const typename Property::Type> get() const;
+    range<const typename Property::Type> get() const;
 
     uint32_t _id;
     SectionRange _range;
     std::shared_ptr<property::Properties> _properties;
 };
-}
-}
+
+} // namespace vasculature
+} // namespace morphio
+
 std::ostream& operator<<(std::ostream& os, const morphio::vasculature::Section& section);
-std::ostream& operator<<(std::ostream& os, morphio::range<const morphio::Point> points);
+std::ostream& operator<<(std::ostream& os, const morphio::range<const morphio::Point>& points);

--- a/include/morphio/vasc/vasculature.h
+++ b/include/morphio/vasc/vasculature.h
@@ -42,17 +42,17 @@ public:
     /**
      * Return a vector with all points from all sections
      **/
-    const Points& points() const noexcept;
+    inline const Points& points() const noexcept;
 
     /**
      * Return a vector with all diameters from all sections
      **/
-    const std::vector<float>& diameters() const noexcept;
+    inline const std::vector<float>& diameters() const noexcept;
 
     /**
      * Return a vector with the section type of every section
      **/
-    const std::vector<property::SectionType::Type>& sectionTypes() const noexcept;
+    inline const std::vector<property::SectionType::Type>& sectionTypes() const noexcept;
 
     /**
      * graph iterators
@@ -64,7 +64,29 @@ private:
     std::shared_ptr<property::Properties> _properties;
 
     template <typename Property>
-    const std::vector<typename Property::Type>& get() const noexcept;
+    inline const std::vector<typename Property::Type>& get() const noexcept;
 };
+
+template <typename Property>
+inline const std::vector<typename Property::Type>& Vasculature::get() const noexcept
+{
+    return _properties->get<Property>();
+}
+
+inline const Points& Vasculature::points() const noexcept
+{
+    return get<property::Point>();
+}
+
+inline const std::vector<float>& Vasculature::diameters() const noexcept
+{
+    return get<property::Diameter>();
+}
+
+inline const std::vector<property::SectionType::Type>& Vasculature::sectionTypes() const noexcept
+{
+    return get<property::SectionType>();
+}
+
 } // namespace vasculature
 } // namespace morphio

--- a/include/morphio/vasc/vasculature.h
+++ b/include/morphio/vasc/vasculature.h
@@ -22,7 +22,7 @@ public:
     explicit Vasculature(const std::string& source);
 
     Vasculature(Vasculature&&) = default;
-    virtual ~Vasculature() {}
+    virtual ~Vasculature() = default;
 
     Vasculature& operator=(const Vasculature&) = default;
     Vasculature& operator=(Vasculature&&) = default;
@@ -30,29 +30,29 @@ public:
     /**
      * Return a vector containing all section objects.
      **/
-    const std::vector<Section> sections() const;
+    std::vector<Section> sections() const;
 
     /**
      * Return the Section with the given id.
      *
      * @throw RawDataError if the id is out of range
      */
-    const Section section(const uint32_t& id) const;
+    Section section(const uint32_t& id) const;
 
     /**
      * Return a vector with all points from all sections
      **/
-    const Points& points() const;
+    const Points& points() const noexcept;
 
     /**
      * Return a vector with all diameters from all sections
      **/
-    const std::vector<float>& diameters() const;
+    const std::vector<float>& diameters() const noexcept;
 
     /**
      * Return a vector with the section type of every section
      **/
-    const std::vector<property::SectionType::Type>& sectionTypes() const;
+    const std::vector<property::SectionType::Type>& sectionTypes() const noexcept;
 
     /**
      * graph iterators
@@ -64,7 +64,7 @@ private:
     std::shared_ptr<property::Properties> _properties;
 
     template <typename Property>
-    const std::vector<typename Property::Type>& get() const;
+    const std::vector<typename Property::Type>& get() const noexcept;
 };
 } // namespace vasculature
 } // namespace morphio

--- a/include/morphio/vector_types.h
+++ b/include/morphio/vector_types.h
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <iostream>
+#include <sstream>
 #include <string>  // std::string
 #include <vector>
 
@@ -27,11 +28,11 @@ Point operator*(T factor, const Point& from);
 template <typename T>
 Point operator/(const Point& from, T factor);
 template <typename T>
-const Point centerOfGravity(const T& points);
+Point centerOfGravity(const T& points);
 template <typename T>
 float maxDistanceToCenterOfGravity(const T& points);
 
-extern template const Point centerOfGravity(const Points&);
+extern template Point centerOfGravity(const Points&);
 extern template float maxDistanceToCenterOfGravity(const Points&);
 
 std::string dumpPoint(const Point& point);
@@ -56,10 +57,9 @@ namespace std {
 template <typename T, size_t N>
 string to_string(const array<T, N>& a)
 {
-    string res;
-    for (auto el : a)
-        res += to_string(el) + ", ";
-    return res;
+    std::ostringstream oss;
+    std::copy(a.begin(), a.end(), std::ostream_iterator<T>(oss, ", "));
+    return oss.str();
 }
 
 } // namespace std

--- a/src/errorMessages.cpp
+++ b/src/errorMessages.cpp
@@ -76,14 +76,14 @@ std::string ErrorMessages::ERROR_LINE_NON_PARSABLE(long unsigned int lineNumber)
 }
 
 std::string ErrorMessages::ERROR_UNSUPPORTED_SECTION_TYPE(long unsigned int lineNumber,
-                                                                const SectionType& type) const
+    const SectionType& type) const
 {
     return errorMsg(lineNumber, ErrorLevel::ERROR,
                     "Unsupported section type: " + std::to_string(type));
 }
 
 std::string ErrorMessages::ERROR_UNSUPPORTED_VASCULATURE_SECTION_TYPE(long unsigned int lineNumber,
-                                                                        const VascularSectionType& type) const
+    const VascularSectionType& type) const
 {
     return errorMsg(lineNumber, ErrorLevel::ERROR,
                             "Unsupported section type: " + std::to_string(type));
@@ -323,11 +323,14 @@ std::string ErrorMessages::WARNING_NEUROMORPHO_SOMA_NON_CONFORM(
           "3 1 x (y+r) z r  1\n\n"
 
           "Got:\n"
-          "1 1 " << x << ' ' << y << ' ' << z << ' ' << r << " -1\n"
-          "2 1 " << _col(child1.point[0], x) << ' '
+          "1 1 "
+       << x << ' ' << y << ' ' << z << ' ' << r << " -1\n"
+                                                   "2 1 "
+       << _col(child1.point[0], x) << ' '
        << _col(child1.point[1], y - r) << ' ' << _col(child1.point[2], z) << ' '
        << _col(child1.diameter / 2.f, r) << " 1\n"
-          "3 1 " << _col(child2.point[0], x) << ' '
+                                            "3 1 "
+       << _col(child2.point[0], x) << ' '
        << _col(child2.point[1], y + r) << ' ' << _col(child2.point[2], z) << ' '
        << _col(child2.diameter / 2.f, r) << " 1\n";
     return ss.str();
@@ -345,9 +348,8 @@ std::string ErrorMessages::WARNING_WRONG_ROOT_POINT(
     const std::vector<Sample>& children) const
 {
     std::ostringstream oss;
-    oss <<
-        "With a 3 points soma, neurites must be connected to the first soma "
-        "point:";
+    oss << "With a 3 points soma, neurites must be connected to the first soma "
+           "point:";
     for (const auto& child : children)
         oss << errorMsg(child.lineNumber, ErrorLevel::WARNING, "");
     return oss.str();

--- a/src/errorMessages.cpp
+++ b/src/errorMessages.cpp
@@ -36,17 +36,14 @@ void LBERROR(Warning warning, const std::string& msg)
         return;
 
     if (MORPHIO_MAX_N_WARNINGS < 0 || error <= MORPHIO_MAX_N_WARNINGS) {
-        std::cerr << msg << std::endl;
+        std::cerr << msg << '\n';
         if (error == MORPHIO_MAX_N_WARNINGS) {
             std::cerr << "Maximum number of warning reached. Next warnings "
-                         "won't be displayed."
-                      << std::endl;
-            std::cerr << "You can change this number by calling:" << std::endl;
-            std::cerr << "\t- C++: set_maximum_warnings(int)" << std::endl;
-            std::cerr << "\t- Python: morphio.set_maximum_warnings(int)"
-                      << std::endl;
-            std::cerr << "0 will print no warning. -1 will print them all"
-                      << std::endl;
+                         "won't be displayed.\n"
+                         "You can change this number by calling:\n"
+                         "\t- C++: set_maximum_warnings(int)\n"
+                         "\t- Python: morphio.set_maximum_warnings(int)\n"
+                         "0 will print no warning. -1 will print them all\n";
         }
         ++error;
     }
@@ -58,7 +55,7 @@ bool ErrorMessages::isIgnored(Warning warning)
     return _ignoredWarnings.find(warning) != _ignoredWarnings.end();
 }
 
-const std::string ErrorMessages::errorMsg(long unsigned int lineNumber, ErrorLevel errorLevel,
+std::string ErrorMessages::errorMsg(long unsigned int lineNumber, ErrorLevel errorLevel,
     std::string msg) const
 {
     return "\n" + (_uri.empty() ? "" : errorLink(lineNumber, errorLevel) + "\n") + msg;
@@ -68,31 +65,31 @@ const std::string ErrorMessages::errorMsg(long unsigned int lineNumber, ErrorLev
 //              ERRORS
 ////////////////////////////////////////////////////////////////////////////////
 
-const std::string ErrorMessages::ERROR_OPENING_FILE() const
+std::string ErrorMessages::ERROR_OPENING_FILE() const
 {
     return "Error opening morphology file:\n" + errorMsg(0, ErrorLevel::ERROR);
 }
 
-const std::string ErrorMessages::ERROR_LINE_NON_PARSABLE(long unsigned int lineNumber) const
+std::string ErrorMessages::ERROR_LINE_NON_PARSABLE(long unsigned int lineNumber) const
 {
     return errorMsg(lineNumber, ErrorLevel::ERROR, "Unable to parse this line");
 }
 
-const std::string ErrorMessages::ERROR_UNSUPPORTED_SECTION_TYPE(long unsigned int lineNumber,
+std::string ErrorMessages::ERROR_UNSUPPORTED_SECTION_TYPE(long unsigned int lineNumber,
                                                                 const SectionType& type) const
 {
     return errorMsg(lineNumber, ErrorLevel::ERROR,
                     "Unsupported section type: " + std::to_string(type));
 }
 
-const std::string ErrorMessages::ERROR_UNSUPPORTED_VASCULATURE_SECTION_TYPE(long unsigned int lineNumber,
+std::string ErrorMessages::ERROR_UNSUPPORTED_VASCULATURE_SECTION_TYPE(long unsigned int lineNumber,
                                                                         const VascularSectionType& type) const
 {
     return errorMsg(lineNumber, ErrorLevel::ERROR,
                             "Unsupported section type: " + std::to_string(type));
 }
 
-const std::string ErrorMessages::ERROR_MULTIPLE_SOMATA(
+std::string ErrorMessages::ERROR_MULTIPLE_SOMATA(
     const std::vector<Sample>& somata) const
 {
     std::string msg("Multiple somata found: ");
@@ -101,7 +98,7 @@ const std::string ErrorMessages::ERROR_MULTIPLE_SOMATA(
     return msg;
 }
 
-const std::string ErrorMessages::ERROR_MISSING_PARENT(
+std::string ErrorMessages::ERROR_MISSING_PARENT(
     const Sample& sample) const
 {
     return errorMsg(sample.lineNumber, ErrorLevel::ERROR,
@@ -126,7 +123,7 @@ std::string ErrorMessages::ERROR_SOMA_WITH_NEURITE_PARENT(
         "Found a soma point with a neurite as parent");
 }
 
-const std::string ErrorMessages::ERROR_REPEATED_ID(
+std::string ErrorMessages::ERROR_REPEATED_ID(
     const Sample& originalSample, const Sample& newSample) const
 {
     return errorMsg(newSample.lineNumber, ErrorLevel::WARNING,
@@ -134,19 +131,19 @@ const std::string ErrorMessages::ERROR_REPEATED_ID(
            "\nID already appears here: \n" + errorLink(originalSample.lineNumber, ErrorLevel::INFO);
 }
 
-const std::string ErrorMessages::ERROR_SELF_PARENT(const Sample& sample) const
+std::string ErrorMessages::ERROR_SELF_PARENT(const Sample& sample) const
 {
     return errorMsg(sample.lineNumber, ErrorLevel::ERROR,
         "Parent ID can not be itself");
 }
 
-const std::string ErrorMessages::ERROR_NOT_IMPLEMENTED_UNDEFINED_SOMA(
+std::string ErrorMessages::ERROR_NOT_IMPLEMENTED_UNDEFINED_SOMA(
     const std::string& method) const
 {
     return "Cannot call: " + method + " on soma of type UNDEFINED";
 }
 
-const std::string ErrorMessages::ERROR_MISSING_MITO_PARENT(
+std::string ErrorMessages::ERROR_MISSING_MITO_PARENT(
     int mitoParentId) const
 {
     return "While trying to append new mitochondria section.\n"
@@ -157,7 +154,7 @@ const std::string ErrorMessages::ERROR_MISSING_MITO_PARENT(
 /**
    Return val1 and highlight it with some color if val1 != val2
 **/
-static const std::string _col(float val1, float val2)
+static std::string _col(float val1, float val2)
 {
     bool is_ok = std::fabs(val1 - val2) < 1e-6f;
     if (is_ok)
@@ -168,27 +165,27 @@ static const std::string _col(float val1, float val2)
 ////////////////////////////////////////////////////////////////////////////////
 //             NEUROLUCIDA
 ////////////////////////////////////////////////////////////////////////////////
-const std::string ErrorMessages::ERROR_SOMA_ALREADY_DEFINED(
+std::string ErrorMessages::ERROR_SOMA_ALREADY_DEFINED(
     long unsigned int lineNumber) const
 {
     return errorMsg(lineNumber, ErrorLevel::ERROR, "A soma is already defined");
 }
 
-const std::string ErrorMessages::ERROR_PARSING_POINT(
+std::string ErrorMessages::ERROR_PARSING_POINT(
     long unsigned int lineNumber, const std::string& point) const
 {
     return errorMsg(lineNumber, ErrorLevel::ERROR,
         "Error converting: \"" + point + "\" to float");
 }
 
-const std::string ErrorMessages::ERROR_UNKNOWN_TOKEN(
+std::string ErrorMessages::ERROR_UNKNOWN_TOKEN(
     long unsigned int lineNumber, const std::string& token) const
 {
     return errorMsg(lineNumber, ErrorLevel::ERROR,
         "Unexpected token: " + token);
 }
 
-const std::string ErrorMessages::ERROR_UNEXPECTED_TOKEN(
+std::string ErrorMessages::ERROR_UNEXPECTED_TOKEN(
     long unsigned int lineNumber, const std::string& expected, const std::string& got,
     const std::string& msg) const
 {
@@ -196,26 +193,26 @@ const std::string ErrorMessages::ERROR_UNEXPECTED_TOKEN(
         "Unexpected token\nExpected: " + expected + " but got " + got + " " + msg);
 }
 
-const std::string ErrorMessages::ERROR_EOF_REACHED(long unsigned int lineNumber) const
+std::string ErrorMessages::ERROR_EOF_REACHED(long unsigned int lineNumber) const
 {
     return errorMsg(lineNumber, ErrorLevel::ERROR,
         "Can't iterate past the end");
 }
 
-const std::string ErrorMessages::ERROR_EOF_IN_NEURITE(long unsigned int lineNumber) const
+std::string ErrorMessages::ERROR_EOF_IN_NEURITE(long unsigned int lineNumber) const
 {
     return errorMsg(lineNumber, ErrorLevel::ERROR,
         "Hit end of file while consuming a neurite");
 }
 
-const std::string ErrorMessages::ERROR_EOF_UNBALANCED_PARENS(
+std::string ErrorMessages::ERROR_EOF_UNBALANCED_PARENS(
     long unsigned int lineNumber) const
 {
     return errorMsg(lineNumber, ErrorLevel::ERROR,
         "Hit end of file before balanced parens");
 }
 
-const std::string ErrorMessages::ERROR_UNCOMPATIBLE_FLAGS(
+std::string ErrorMessages::ERROR_UNCOMPATIBLE_FLAGS(
     morphio::Option flag1, morphio::Option flag2) const
 {
     return errorMsg(0, ErrorLevel::ERROR,
@@ -226,8 +223,8 @@ const std::string ErrorMessages::ERROR_UNCOMPATIBLE_FLAGS(
 //              WRITERS
 ////////////////////////////////////////////////////////////////////////////////
 
-const std::string ErrorMessages::ERROR_WRONG_EXTENSION(
-    const std::string filename) const
+std::string ErrorMessages::ERROR_WRONG_EXTENSION(
+    const std::string& filename) const
 {
     return "Filename: " + filename + " must have one of the following extensions: swc, asc or h5";
 }
@@ -298,7 +295,7 @@ std::string ErrorMessages::WARNING_WRONG_DUPLICATE(
         msg + "\nThe section first point " + "should be parent section last point: " + "\n        : X Y Z Diameter" + "\nparent last point :[" + std::to_string(p0[0]) + ", " + std::to_string(p0[1]) + ", " + std::to_string(p0[2]) + ", " + std::to_string(d0) + "]" + "\nchild first point :[" + std::to_string(p1[0]) + ", " + std::to_string(p1[1]) + ", " + std::to_string(p1[2]) + ", " + std::to_string(d1) + "]\n");
 }
 
-const std::string ErrorMessages::WARNING_ONLY_CHILD(const DebugInfo& info,
+std::string ErrorMessages::WARNING_ONLY_CHILD(const DebugInfo& info,
     unsigned int parentId,
     unsigned int childId) const
 {
@@ -313,27 +310,26 @@ const std::string ErrorMessages::WARNING_ONLY_CHILD(const DebugInfo& info,
     return "\nSection: " + std::to_string(childId) + childMsg + " is the only child of " + "section: " + std::to_string(parentId) + parentMsg + "\nIt will be merged with the parent section";
 }
 
-const std::string ErrorMessages::WARNING_NEUROMORPHO_SOMA_NON_CONFORM(
+std::string ErrorMessages::WARNING_NEUROMORPHO_SOMA_NON_CONFORM(
     const Sample& root, const Sample& child1, const Sample& child2)
 {
     float x = root.point[0], y = root.point[1], z = root.point[2],
           r = root.diameter / 2.f;
     std::stringstream ss;
-    ss << "The soma does not conform the three point soma spec" << std::endl;
-    ss << "The only valid neuro-morpho soma is:" << std::endl;
-    ss << "1 1 x   y   z r -1" << std::endl;
-    ss << "2 1 x (y-r) z r  1" << std::endl;
-    ss << "3 1 x (y+r) z r  1\n"
-       << std::endl;
+    ss << "The soma does not conform the three point soma spec\n"
+          "The only valid neuro-morpho soma is:\n"
+          "1 1 x   y   z r -1\n"
+          "2 1 x (y-r) z r  1\n"
+          "3 1 x (y+r) z r  1\n\n"
 
-    ss << "Got:" << std::endl;
-    ss << "1 1 " << x << " " << y << " " << z << " " << r << " -1" << std::endl;
-    ss << "2 1 " << _col(child1.point[0], x) << " "
-       << _col(child1.point[1], y - r) << " " << _col(child1.point[2], z) << " "
-       << _col(child1.diameter / 2.f, r) << " 1" << std::endl;
-    ss << "3 1 " << _col(child2.point[0], x) << " "
-       << _col(child2.point[1], y + r) << " " << _col(child2.point[2], z) << " "
-       << _col(child2.diameter / 2.f, r) << " 1" << std::endl;
+          "Got:\n"
+          "1 1 " << x << ' ' << y << ' ' << z << ' ' << r << " -1\n"
+          "2 1 " << _col(child1.point[0], x) << ' '
+       << _col(child1.point[1], y - r) << ' ' << _col(child1.point[2], z) << ' '
+       << _col(child1.diameter / 2.f, r) << " 1\n"
+          "3 1 " << _col(child2.point[0], x) << ' '
+       << _col(child2.point[1], y + r) << ' ' << _col(child2.point[2], z) << ' '
+       << _col(child2.diameter / 2.f, r) << " 1\n";
     return ss.str();
 }
 
@@ -348,12 +344,13 @@ std::string ErrorMessages::WARNING_MITOCHONDRIA_WRITE_NOT_SUPPORTED() const
 std::string ErrorMessages::WARNING_WRONG_ROOT_POINT(
     const std::vector<Sample>& children) const
 {
-    std::string msg =
+    std::ostringstream oss;
+    oss <<
         "With a 3 points soma, neurites must be connected to the first soma "
         "point:";
-    for (auto child : children)
-        msg += errorMsg(child.lineNumber, ErrorLevel::WARNING, "");
-    return msg;
+    for (const auto& child : children)
+        oss << errorMsg(child.lineNumber, ErrorLevel::WARNING, "");
+    return oss.str();
 }
 
 } // namespace readers

--- a/src/mito_section.cpp
+++ b/src/mito_section.cpp
@@ -34,17 +34,17 @@ mito_upstream_iterator MitoSection::upstream_end() const
     return mito_upstream_iterator();
 }
 
-const range<const uint32_t> MitoSection::neuriteSectionIds() const
+range<const uint32_t> MitoSection::neuriteSectionIds() const
 {
     return get<Property::MitoNeuriteSectionId>();
 }
 
-const range<const float> MitoSection::diameters() const
+range<const float> MitoSection::diameters() const
 {
     return get<Property::MitoDiameter>();
 }
 
-const range<const float> MitoSection::relativePathLengths() const
+range<const float> MitoSection::relativePathLengths() const
 {
     return get<Property::MitoPathLength>();
 }

--- a/src/mitochondria.cpp
+++ b/src/mitochondria.cpp
@@ -9,29 +9,28 @@ MitoSection Mitochondria::section(uint32_t id) const
 
 std::vector<MitoSection> Mitochondria::sections() const
 {
-    std::vector<MitoSection> sections;
+    std::vector<MitoSection> sections_;
     for (unsigned int i = 0;
          i < _properties->get<morphio::Property::MitoSection>().size(); ++i) {
-        sections.push_back(section(i));
+        sections_.push_back(section(i));
     }
-    return sections;
+    return sections_;
 }
 
 std::vector<MitoSection> Mitochondria::rootSections() const
 {
     std::vector<MitoSection> result;
-    try {
-        const std::vector<uint32_t>& children = _properties->children<morphio::Property::MitoSection>().at(-1);
+    const auto& mitoChildren = _properties->children<morphio::Property::MitoSection>();
+    const auto& it = mitoChildren.find(-1);
+    if (it != mitoChildren.end()) {
+        const auto& children = it->second;
 
         result.reserve(children.size());
         for (auto id : children) {
             result.push_back(section(id));
         }
-
-        return result;
-    } catch (const std::out_of_range&) {
-        return result;
     }
+    return result;
 }
 
 } // namespace morphio

--- a/src/mitochondria.cpp
+++ b/src/mitochondria.cpp
@@ -2,22 +2,22 @@
 #include <morphio/mitochondria.h>
 
 namespace morphio {
-const MitoSection Mitochondria::section(const uint32_t& id) const
+MitoSection Mitochondria::section(uint32_t id) const
 {
-    return MitoSection(id, _properties);
+    return {id, _properties};
 }
 
-const std::vector<MitoSection> Mitochondria::sections() const
+std::vector<MitoSection> Mitochondria::sections() const
 {
-    std::vector<MitoSection> sections_;
+    std::vector<MitoSection> sections;
     for (unsigned int i = 0;
          i < _properties->get<morphio::Property::MitoSection>().size(); ++i) {
-        sections_.push_back(section(i));
+        sections.push_back(section(i));
     }
-    return sections_;
+    return sections;
 }
 
-const std::vector<MitoSection> Mitochondria::rootSections() const
+std::vector<MitoSection> Mitochondria::rootSections() const
 {
     std::vector<MitoSection> result;
     try {

--- a/src/morphology.cpp
+++ b/src/morphology.cpp
@@ -72,21 +72,19 @@ Morphology::Morphology(mut::Morphology morphology)
     buildChildren(_properties);
 }
 
-Morphology::Morphology(Morphology&&) = default;
-Morphology& Morphology::operator=(Morphology&&) = default;
+Morphology::Morphology(Morphology&&) noexcept = default;
+Morphology& Morphology::operator=(Morphology&&) noexcept = default;
 
-Morphology::~Morphology()
-{
-}
+Morphology::~Morphology() = default;
 
 Soma Morphology::soma() const
 {
-    return {_properties};
+    return Soma(_properties);
 }
 
 Mitochondria Morphology::mitochondria() const
 {
-    return {_properties};
+    return Mitochondria(_properties);
 }
 
 const std::vector<Property::Annotation>& Morphology::annotations() const
@@ -94,7 +92,7 @@ const std::vector<Property::Annotation>& Morphology::annotations() const
     return _properties->_annotations;
 }
 
-Section Morphology::section(const uint32_t& id) const
+Section Morphology::section(uint32_t id) const
 {
     return {id, _properties};
 }
@@ -133,7 +131,7 @@ const std::vector<typename Property::Type>& Morphology::get() const
     return _properties->get<Property>();
 }
 
-const Points& Morphology::points() const
+const Points& Morphology::points() const noexcept
 {
     return get<Property::Point>();
 }

--- a/src/mut/mito_section.cpp
+++ b/src/mut/mito_section.cpp
@@ -87,7 +87,7 @@ std::shared_ptr<MitoSection> MitoSection::appendSection(
     return ptr;
 }
 
-const std::shared_ptr<MitoSection> MitoSection::parent() const
+std::shared_ptr<MitoSection> MitoSection::parent() const
 {
     return _mitochondria->_sections.at(_mitochondria->_parent.at(id()));
 }
@@ -102,13 +102,15 @@ bool MitoSection::isRoot() const
     }
 }
 
-const std::vector<std::shared_ptr<MitoSection>> MitoSection::children() const
+const std::vector<std::shared_ptr<MitoSection>>& MitoSection::children() const
 {
-    try {
-        return _mitochondria->_children.at(id());
-    } catch (const std::out_of_range&) {
-        return std::vector<std::shared_ptr<MitoSection>>();
+    const auto& children = _mitochondria->_children;
+    const auto it = children.find(id());
+    if (it == children.end()) {
+        static std::vector<std::shared_ptr<MitoSection>> empty;
+        return empty;
     }
+    return it->second;
 }
 
 } // namespace mut

--- a/src/mut/mito_section.cpp
+++ b/src/mut/mito_section.cpp
@@ -35,8 +35,8 @@ std::shared_ptr<MitoSection> MitoSection::appendSection(
     unsigned int parentId = id();
 
     std::shared_ptr<MitoSection> ptr(new MitoSection(_mitochondria,
-                                         _mitochondria->_counter,
-                                         points));
+        _mitochondria->_counter,
+        points));
 
     uint32_t childId = _mitochondria->_register(ptr);
 
@@ -49,8 +49,8 @@ std::shared_ptr<MitoSection> MitoSection::appendSection(
     const std::shared_ptr<MitoSection>& original_section, bool recursive)
 {
     std::shared_ptr<MitoSection> ptr(new MitoSection(_mitochondria,
-                                         _mitochondria->_counter,
-                                         *original_section));
+        _mitochondria->_counter,
+        *original_section));
     unsigned int parentId = id();
     uint32_t id_ = _mitochondria->_register(ptr);
 
@@ -70,8 +70,8 @@ std::shared_ptr<MitoSection> MitoSection::appendSection(
     const morphio::MitoSection& section, bool recursive)
 {
     std::shared_ptr<MitoSection> ptr(new MitoSection(_mitochondria,
-                                         _mitochondria->_counter,
-                                         section));
+        _mitochondria->_counter,
+        section));
     unsigned int parentId = id();
     uint32_t childId = _mitochondria->_register(ptr);
 

--- a/src/mut/mito_section.cpp
+++ b/src/mut/mito_section.cpp
@@ -36,8 +36,7 @@ std::shared_ptr<MitoSection> MitoSection::appendSection(
 
     std::shared_ptr<MitoSection> ptr(new MitoSection(_mitochondria,
                                          _mitochondria->_counter,
-                                         points),
-        friendDtorForSharedPtrMito);
+                                         points));
 
     uint32_t childId = _mitochondria->_register(ptr);
 
@@ -47,12 +46,11 @@ std::shared_ptr<MitoSection> MitoSection::appendSection(
 }
 
 std::shared_ptr<MitoSection> MitoSection::appendSection(
-    std::shared_ptr<MitoSection> original_section, bool recursive)
+    const std::shared_ptr<MitoSection>& original_section, bool recursive)
 {
     std::shared_ptr<MitoSection> ptr(new MitoSection(_mitochondria,
                                          _mitochondria->_counter,
-                                         *original_section),
-        friendDtorForSharedPtrMito);
+                                         *original_section));
     unsigned int parentId = id();
     uint32_t id_ = _mitochondria->_register(ptr);
 
@@ -73,8 +71,7 @@ std::shared_ptr<MitoSection> MitoSection::appendSection(
 {
     std::shared_ptr<MitoSection> ptr(new MitoSection(_mitochondria,
                                          _mitochondria->_counter,
-                                         section),
-        friendDtorForSharedPtrMito);
+                                         section));
     unsigned int parentId = id();
     uint32_t childId = _mitochondria->_register(ptr);
 

--- a/src/mut/mitochondria.cpp
+++ b/src/mut/mitochondria.cpp
@@ -58,20 +58,15 @@ static void _appendMitoProperties(Property::MitochondriaPointLevel& to,
     _appendVector(to._diameters, from._diameters, offset);
 }
 
-std::vector<Mitochondria::MitoSectionP> Mitochondria::children(
+const std::vector<Mitochondria::MitoSectionP>& Mitochondria::children(
     const MitoSectionP& section_) const
 {
-    try {
-        return _children.at(section_->id());
-    } catch (const std::out_of_range&) {
-        return {};
+    const auto it = _children.find(section_->id());
+    if (it == _children.end()) {
+        static std::vector<Mitochondria::MitoSectionP >empty;
+        return empty;
     }
-}
-
-const std::vector<Mitochondria::MitoSectionP>& Mitochondria::rootSections()
-    const noexcept
-{
-    return _rootSections;
+    return it->second;
 }
 
 const Mitochondria::MitoSectionP& Mitochondria::parent(
@@ -93,12 +88,6 @@ bool Mitochondria::isRoot(const MitoSectionP& section_) const
 const Mitochondria::MitoSectionP& Mitochondria::section(uint32_t id) const
 {
     return _sections.at(id);
-}
-
-const std::map<uint32_t, Mitochondria::MitoSectionP>& Mitochondria::sections()
-    const
-{
-    return _sections;
 }
 
 void Mitochondria::_buildMitochondria(Property::Properties& properties) const
@@ -129,7 +118,7 @@ void Mitochondria::_buildMitochondria(Property::Properties& properties) const
     }
 }
 
-const std::shared_ptr<MitoSection> Mitochondria::mitoSection(uint32_t id_) const
+const std::shared_ptr<MitoSection>& Mitochondria::mitoSection(uint32_t id_) const
 {
     return _sections.at(id_);
 }

--- a/src/mut/mitochondria.cpp
+++ b/src/mut/mitochondria.cpp
@@ -6,16 +6,10 @@
 namespace morphio {
 namespace mut {
 
-void friendDtorForSharedPtrMito(MitoSection* section)
-{
-    delete section;
-}
-
-std::shared_ptr<MitoSection> Mitochondria::appendRootSection(
+Mitochondria::MitoSectionP Mitochondria::appendRootSection(
     const morphio::MitoSection& section_, bool recursive)
 {
-    std::shared_ptr<MitoSection> ptr(new MitoSection(this, _counter, section_),
-        friendDtorForSharedPtrMito);
+    const auto ptr = std::make_shared<MitoSection>(this, _counter, section_);
     _register(ptr);
     _rootSections.push_back(ptr);
 
@@ -28,12 +22,10 @@ std::shared_ptr<MitoSection> Mitochondria::appendRootSection(
     return ptr;
 }
 
-std::shared_ptr<MitoSection> Mitochondria::appendRootSection(
-    std::shared_ptr<MitoSection> section_, bool recursive)
+Mitochondria::MitoSectionP Mitochondria::appendRootSection(
+    const MitoSectionP& section_, bool recursive)
 {
-    std::shared_ptr<MitoSection> section_copy(new MitoSection(this, _counter,
-                                                  *section_),
-        friendDtorForSharedPtrMito);
+    const auto section_copy = std::make_shared<MitoSection>(this, _counter, *section_);
     _register(section_copy);
     _rootSections.push_back(section_copy);
 
@@ -46,12 +38,10 @@ std::shared_ptr<MitoSection> Mitochondria::appendRootSection(
     return section_copy;
 }
 
-std::shared_ptr<MitoSection> Mitochondria::appendRootSection(
+Mitochondria::MitoSectionP Mitochondria::appendRootSection(
     const Property::MitochondriaPointLevel& pointProperties)
 {
-    std::shared_ptr<MitoSection> ptr(new MitoSection(this, _counter,
-                                         pointProperties),
-        friendDtorForSharedPtrMito);
+    const auto ptr = std::make_shared<MitoSection>(this, _counter, pointProperties);
     _register(ptr);
     _rootSections.push_back(ptr);
 
@@ -68,29 +58,29 @@ static void _appendMitoProperties(Property::MitochondriaPointLevel& to,
     _appendVector(to._diameters, from._diameters, offset);
 }
 
-const std::vector<std::shared_ptr<MitoSection>> Mitochondria::children(
-    std::shared_ptr<MitoSection> section_) const
+std::vector<Mitochondria::MitoSectionP> Mitochondria::children(
+    const MitoSectionP& section_) const
 {
     try {
         return _children.at(section_->id());
     } catch (const std::out_of_range&) {
-        return std::vector<std::shared_ptr<MitoSection>>();
+        return {};
     }
 }
 
-const std::vector<std::shared_ptr<MitoSection>>& Mitochondria::rootSections()
-    const
+const std::vector<Mitochondria::MitoSectionP>& Mitochondria::rootSections()
+    const noexcept
 {
     return _rootSections;
 }
 
-const std::shared_ptr<MitoSection> Mitochondria::parent(
-    const std::shared_ptr<MitoSection> parent_) const
+const Mitochondria::MitoSectionP& Mitochondria::parent(
+    const MitoSectionP& parent_) const
 {
     return section(_parent.at(parent_->id()));
 }
 
-bool Mitochondria::isRoot(const std::shared_ptr<MitoSection> section_) const
+bool Mitochondria::isRoot(const MitoSectionP& section_) const
 {
     try {
         parent(section_);
@@ -100,12 +90,12 @@ bool Mitochondria::isRoot(const std::shared_ptr<MitoSection> section_) const
     }
 }
 
-const std::shared_ptr<MitoSection> Mitochondria::section(uint32_t id) const
+const Mitochondria::MitoSectionP& Mitochondria::section(uint32_t id) const
 {
     return _sections.at(id);
 }
 
-const std::map<uint32_t, std::shared_ptr<MitoSection>> Mitochondria::sections()
+const std::map<uint32_t, Mitochondria::MitoSectionP>& Mitochondria::sections()
     const
 {
     return _sections;
@@ -145,7 +135,7 @@ const std::shared_ptr<MitoSection> Mitochondria::mitoSection(uint32_t id_) const
 }
 
 mito_depth_iterator Mitochondria::depth_begin(
-    std::shared_ptr<MitoSection> section_) const
+    const MitoSectionP& section_) const
 {
     return mito_depth_iterator(section_);
 }
@@ -156,7 +146,7 @@ mito_depth_iterator Mitochondria::depth_end() const
 }
 
 mito_breadth_iterator Mitochondria::breadth_begin(
-    std::shared_ptr<MitoSection> section_) const
+    const MitoSectionP& section_) const
 {
     return mito_breadth_iterator(section_);
 }
@@ -167,7 +157,7 @@ mito_breadth_iterator Mitochondria::breadth_end() const
 }
 
 mito_upstream_iterator Mitochondria::upstream_begin(
-    std::shared_ptr<MitoSection> section_) const
+    const MitoSectionP& section_) const
 {
     return mito_upstream_iterator(section_);
 }
@@ -177,7 +167,7 @@ mito_upstream_iterator Mitochondria::upstream_end() const
     return mito_upstream_iterator();
 }
 
-uint32_t Mitochondria::_register(std::shared_ptr<MitoSection> section_)
+uint32_t Mitochondria::_register(const MitoSectionP& section_)
 {
     if (_sections.count(section_->id()))
         LBTHROW(SectionBuilderError("Section already exists"));

--- a/src/mut/morphology.cpp
+++ b/src/mut/morphology.cpp
@@ -137,7 +137,7 @@ std::shared_ptr<Section> Morphology::appendRootSection(
     const Property::PointLevel& pointProperties, SectionType type)
 {
     const std::shared_ptr<Section> ptr(new Section(this, _counter, type,
-                                     pointProperties));
+        pointProperties));
     _register(ptr);
     _rootSections.push_back(ptr);
 
@@ -279,7 +279,7 @@ Property::Properties Morphology::buildReadOnly() const
     using std::setw;
     int sectionIdOnDisk = 0;
     std::map<uint32_t, int32_t> newIds;
-    Property::Properties properties{};
+    Property::Properties properties {};
 
     if (_cellProperties) {
         properties._cellLevel = *_cellProperties;

--- a/src/mut/morphology.cpp
+++ b/src/mut/morphology.cpp
@@ -17,8 +17,6 @@ namespace mut {
 
 void _appendProperties(Property::PointLevel& to,
     const Property::PointLevel& from, int offset);
-void eraseByValue(std::vector<std::shared_ptr<Section>>& vec,
-    std::shared_ptr<Section> section);
 
 using morphio::readers::ErrorMessages;
 Morphology::Morphology(const morphio::URI& uri, unsigned int options)
@@ -68,8 +66,8 @@ Morphology::Morphology(const morphio::Morphology& morphology, unsigned int optio
 /**
    Return false if there is no duplicate point
  **/
-bool _checkDuplicatePoint(std::shared_ptr<Section> parent,
-    std::shared_ptr<Section> current)
+bool _checkDuplicatePoint(const std::shared_ptr<Section>& parent,
+    const std::shared_ptr<Section>& current)
 {
     // Weird edge case where parent is empty: skipping it
     if (parent->points().empty())
@@ -78,7 +76,7 @@ bool _checkDuplicatePoint(std::shared_ptr<Section> parent,
     if (current->points().empty())
         return false;
 
-    if (parent->points()[parent->points().size() - 1] != current->points()[0])
+    if (parent->points().back() != current->points().front())
         return false;
 
     // // As perimeter is optional, it must either be defined for parent and
@@ -98,12 +96,11 @@ bool _checkDuplicatePoint(std::shared_ptr<Section> parent,
 std::shared_ptr<Section> Morphology::appendRootSection(
     const morphio::Section& section_, bool recursive)
 {
-    std::shared_ptr<Section> ptr(new Section(this, _counter, section_),
-        friendDtorForSharedPtr);
+    const std::shared_ptr<Section> ptr(new Section(this, _counter, section_));
     _register(ptr);
     _rootSections.push_back(ptr);
 
-    bool emptySection = ptr->points().empty();
+    const bool emptySection = ptr->points().empty();
     if (emptySection)
         LBERROR(Warning::APPENDING_EMPTY_SECTION, _err.WARNING_APPENDING_EMPTY_SECTION(ptr));
 
@@ -117,14 +114,13 @@ std::shared_ptr<Section> Morphology::appendRootSection(
 }
 
 std::shared_ptr<Section> Morphology::appendRootSection(
-    std::shared_ptr<Section> section_, bool recursive)
+    const std::shared_ptr<Section>& section_, bool recursive)
 {
-    std::shared_ptr<Section> section_copy(new Section(this, _counter, *section_),
-        friendDtorForSharedPtr);
+    const std::shared_ptr<Section> section_copy(new Section(this, _counter, *section_));
     _register(section_copy);
     _rootSections.push_back(section_copy);
 
-    bool emptySection = section_copy->points().empty();
+    const bool emptySection = section_copy->points().empty();
     if (emptySection)
         LBERROR(Warning::APPENDING_EMPTY_SECTION, _err.WARNING_APPENDING_EMPTY_SECTION(section_copy));
 
@@ -140,9 +136,8 @@ std::shared_ptr<Section> Morphology::appendRootSection(
 std::shared_ptr<Section> Morphology::appendRootSection(
     const Property::PointLevel& pointProperties, SectionType type)
 {
-    std::shared_ptr<Section> ptr(new Section(this, _counter, type,
-                                     pointProperties),
-        friendDtorForSharedPtr);
+    const std::shared_ptr<Section> ptr(new Section(this, _counter, type,
+                                     pointProperties));
     _register(ptr);
     _rootSections.push_back(ptr);
 
@@ -153,12 +148,7 @@ std::shared_ptr<Section> Morphology::appendRootSection(
     return ptr;
 }
 
-void friendDtorForSharedPtr(Section* section)
-{
-    delete section;
-}
-
-uint32_t Morphology::_register(std::shared_ptr<Section> section_)
+uint32_t Morphology::_register(const std::shared_ptr<Section>& section_)
 {
     if (_sections.count(section_->id()))
         LBTHROW(SectionBuilderError("Section already exists"));
@@ -168,47 +158,21 @@ uint32_t Morphology::_register(std::shared_ptr<Section> section_)
     return section_->id();
 }
 
-std::shared_ptr<Soma> Morphology::soma()
-{
-    return _soma;
-}
-
-const std::shared_ptr<Soma> Morphology::soma() const
-{
-    return _soma;
-}
-
-const std::vector<Property::Annotation> Morphology::annotations() const
-{
-    return _annotations;
-}
-
-const std::vector<std::shared_ptr<Section>>& Morphology::rootSections() const
-{
-    return _rootSections;
-}
-
 Morphology::~Morphology()
 {
     auto roots = _rootSections; // Need to iterate on a copy
-    for (auto root : roots) {
+    for (const auto& root : roots) {
         deleteSection(root, true);
     }
 }
 
-const std::map<uint32_t, std::shared_ptr<Section>> Morphology::sections() const
-{
-    return _sections;
-}
-
-
-void eraseByValue(std::vector<std::shared_ptr<Section>>& vec,
-    std::shared_ptr<Section> section)
+static void eraseByValue(std::vector<std::shared_ptr<Section>>& vec,
+    const std::shared_ptr<Section>& section)
 {
     vec.erase(std::remove(vec.begin(), vec.end(), section), vec.end());
 }
 
-void Morphology::deleteSection(std::shared_ptr<Section> section_, bool recursive)
+void Morphology::deleteSection(const std::shared_ptr<Section>& section_, bool recursive)
 
 {
     if (!section_)
@@ -219,18 +183,14 @@ void Morphology::deleteSection(std::shared_ptr<Section> section_, bool recursive
         // The deletion must start by the furthest leaves, otherwise you may cut
         // the topology and forget to remove some sections
         std::vector<std::shared_ptr<Section>> ids;
-        for (auto it = section_->breadth_begin(); it != breadth_end(); ++it) {
-            ids.push_back(*it);
-        }
+        std::copy(section_->breadth_begin(), breadth_end(),
+            std::back_inserter(ids));
 
         for (auto it = ids.rbegin(); it != ids.rend(); ++it) {
-            auto child = *it;
-            {
-                deleteSection(child, false);
-            }
+            deleteSection(*it, false);
         }
     } else {
-        for (auto child : section_->children()) {
+        for (auto& child : section_->children()) {
             // Re-link children to their "grand-parent"
             _parent[child->id()] = _parent[id];
             _children[_parent[id]].push_back(child);
@@ -314,12 +274,12 @@ void Morphology::sanitize(const morphio::readers::DebugInfo& debugInfo)
     }
 }
 
-const Property::Properties Morphology::buildReadOnly() const
+Property::Properties Morphology::buildReadOnly() const
 {
     using std::setw;
     int sectionIdOnDisk = 0;
     std::map<uint32_t, int32_t> newIds;
-    Property::Properties properties;
+    Property::Properties properties{};
 
     if (_cellProperties) {
         properties._cellLevel = *_cellProperties;
@@ -328,7 +288,7 @@ const Property::Properties Morphology::buildReadOnly() const
     _appendProperties(properties._somaLevel, _soma->_pointProperties);
 
     for (auto it = depth_begin(); it != depth_end(); ++it) {
-        std::shared_ptr<Section> section_ = *it;
+        const std::shared_ptr<Section>& section_ = *it;
         unsigned int sectionId = section_->id();
         int parentOnDisk = (section_->isRoot() ? -1 : newIds[section_->parent()->id()]);
 
@@ -342,11 +302,6 @@ const Property::Properties Morphology::buildReadOnly() const
     mitochondria()._buildMitochondria(properties);
     properties._annotations = annotations();
     return properties;
-}
-
-const std::shared_ptr<Section> Morphology::section(uint32_t id) const
-{
-    return _sections.at(id);
 }
 
 depth_iterator Morphology::depth_begin() const

--- a/src/mut/section.cpp
+++ b/src/mut/section.cpp
@@ -36,7 +36,7 @@ Section::Section(Morphology* morphology, unsigned int id_, const Section& sectio
 {
 }
 
-const std::shared_ptr<Section> Section::parent() const
+const std::shared_ptr<Section>& Section::parent() const
 {
     return _morphology->_sections.at(_morphology->_parent.at(id()));
 }
@@ -51,12 +51,13 @@ bool Section::isRoot() const
     }
 }
 
-const std::vector<std::shared_ptr<Section>> Section::children() const
+const std::vector<std::shared_ptr<Section>>& Section::children() const
 {
     try {
         return _morphology->_children.at(id());
     } catch (const std::out_of_range&) {
-        return std::vector<std::shared_ptr<Section>>();
+        static std::vector<std::shared_ptr<Section>> empty;
+        return empty;
     }
 }
 
@@ -90,13 +91,13 @@ upstream_iterator Section::upstream_end() const
     return upstream_iterator();
 }
 
-static std::ostream& operator<<(std::ostream& os, Section& section)
+static std::ostream& operator<<(std::ostream& os, const Section& section)
 {
     ::operator<<(os, section);
     return os;
 }
 
-std::ostream& operator<<(std::ostream& os, const std::shared_ptr<Section> sectionPtr)
+std::ostream& operator<<(std::ostream& os, const std::shared_ptr<Section>& sectionPtr)
 {
     os << *sectionPtr;
     return os;
@@ -110,9 +111,8 @@ bool _emptySection(const std::shared_ptr<Section> section)
 std::shared_ptr<Section> Section::appendSection(
     std::shared_ptr<Section> original_section, bool recursive)
 {
-    std::shared_ptr<Section> ptr(new Section(_morphology, _morphology->_counter,
-                                     *original_section),
-        friendDtorForSharedPtr);
+    const std::shared_ptr<Section> ptr(new Section(_morphology, _morphology->_counter,
+                                     *original_section));
     unsigned int parentId = id();
     uint32_t childId = _morphology->_register(ptr);
     auto& _sections = _morphology->_sections;
@@ -143,9 +143,8 @@ std::shared_ptr<Section> Section::appendSection(
 std::shared_ptr<Section> Section::appendSection(const morphio::Section& section,
     bool recursive)
 {
-    std::shared_ptr<Section> ptr(new Section(_morphology, _morphology->_counter,
-                                     section),
-        friendDtorForSharedPtr);
+    const std::shared_ptr<Section> ptr(new Section(_morphology, _morphology->_counter,
+                                     section));
     unsigned int parentId = id();
     uint32_t childId = _morphology->_register(ptr);
     auto& _sections = _morphology->_sections;
@@ -184,10 +183,8 @@ std::shared_ptr<Section> Section::appendSection(
         LBTHROW(morphio::SectionBuilderError(
             "Cannot create section with type soma"));
 
-    Section* p = new Section(_morphology, _morphology->_counter, sectionType,
-        pointProperties);
-
-    std::shared_ptr<Section> ptr(p, friendDtorForSharedPtr);
+    std::shared_ptr<Section> ptr(new Section(_morphology, _morphology->_counter, sectionType,
+        pointProperties));
 
     uint32_t childId = _morphology->_register(ptr);
 

--- a/src/mut/section.cpp
+++ b/src/mut/section.cpp
@@ -112,7 +112,7 @@ std::shared_ptr<Section> Section::appendSection(
     std::shared_ptr<Section> original_section, bool recursive)
 {
     const std::shared_ptr<Section> ptr(new Section(_morphology, _morphology->_counter,
-                                     *original_section));
+        *original_section));
     unsigned int parentId = id();
     uint32_t childId = _morphology->_register(ptr);
     auto& _sections = _morphology->_sections;
@@ -144,7 +144,7 @@ std::shared_ptr<Section> Section::appendSection(const morphio::Section& section,
     bool recursive)
 {
     const std::shared_ptr<Section> ptr(new Section(_morphology, _morphology->_counter,
-                                     section));
+        section));
     unsigned int parentId = id();
     uint32_t childId = _morphology->_register(ptr);
     auto& _sections = _morphology->_sections;

--- a/src/mut/soma.cpp
+++ b/src/mut/soma.cpp
@@ -26,7 +26,7 @@ Soma::Soma(const morphio::Soma& soma)
 {
 }
 
-const Point Soma::center() const
+Point Soma::center() const
 {
     return centerOfGravity(points());
 }
@@ -43,13 +43,13 @@ float Soma::maxDistance() const
     return maxDistanceToCenterOfGravity(_pointProperties._points);
 }
 
-std::ostream& operator<<(std::ostream& os, Soma& soma)
+std::ostream& operator<<(std::ostream& os, const Soma& soma)
 {
     os << dumpPoints(soma.points());
     return os;
 }
 
-std::ostream& operator<<(std::ostream& os, std::shared_ptr<Soma> somaPtr)
+std::ostream& operator<<(std::ostream& os, const std::shared_ptr<Soma>& somaPtr)
 {
     os << *somaPtr;
     return os;

--- a/src/mut/writers.cpp
+++ b/src/mut/writers.cpp
@@ -244,7 +244,7 @@ static void mitochondriaH5(HighFive::File& h5_file, const Mitochondria& mitochon
 
     auto& s = properties._mitochondriaSectionLevel;
     structure.reserve(s._sections.size());
-    for (const auto& section: s._sections) {
+    for (const auto& section : s._sections) {
         structure.push_back({section[0], section[1]});
     }
 

--- a/src/mut/writers.cpp
+++ b/src/mut/writers.cpp
@@ -166,16 +166,17 @@ void asc(const Morphology& morphology, const std::string& filename)
     header[SECTION_DENDRITE] = "( (Color Red)\n  (Dendrite)\n";
     header[SECTION_APICAL_DENDRITE] = "( (Color Red)\n  (Apical)\n";
 
-    if (!morphology.soma()->points().empty()) {
+    const auto& soma = morphology.soma();
+    if (!soma->points().empty()) {
         myfile << "(\"CellBody\"\n  (Color Red)\n  (CellBody)\n";
-        _write_asc_points(myfile, morphology.soma()->points(), morphology.soma()->diameters(), 2);
+        _write_asc_points(myfile, soma->points(), soma->diameters(), 2);
         myfile << ")\n\n";
     } else {
         LBERROR(Warning::WRITE_NO_SOMA,
             readers::ErrorMessages().WARNING_WRITE_NO_SOMA());
     }
 
-    for (auto& section : morphology.rootSections()) {
+    for (const auto& section : morphology.rootSections()) {
         myfile << header.at(section->type());
         _write_asc_section(myfile, morphology, section, 2);
         myfile << ")\n\n";

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -13,9 +13,9 @@ namespace Property {
 PointLevel::PointLevel(std::vector<Point::Type> points,
     std::vector<Diameter::Type> diameters,
     std::vector<Perimeter::Type> perimeters)
-    : _points(points)
-    , _diameters(diameters)
-    , _perimeters(perimeters)
+    : _points(std::move(points))
+    , _diameters(std::move(diameters))
+    , _perimeters(std::move(perimeters))
 {
     if (_points.size() != _diameters.size())
         throw SectionBuilderError(
@@ -201,8 +201,8 @@ bool SectionLevel::operator!=(const SectionLevel& other) const
 bool CellLevel::diff(const CellLevel& other, LogLevel logLevel) const
 {
     if (logLevel && this->_cellFamily != other._cellFamily) {
-        std::cout << "this->_cellFamily: " << this->_cellFamily << std::endl;
-        std::cout << "other._cellFamily: " << other._cellFamily << std::endl;
+        std::cout << "this->_cellFamily: " << this->_cellFamily << '\n'
+                  << "other._cellFamily: " << other._cellFamily << '\n';
     }
     return !(this == &other || (this->_cellFamily == other._cellFamily
                                  // this->_somaType == other._somaType
@@ -221,7 +221,7 @@ bool CellLevel::operator!=(const CellLevel& other) const
 
 
 MitochondriaPointLevel::MitochondriaPointLevel(
-    const MitochondriaPointLevel& data, SectionRange range)
+    const MitochondriaPointLevel& data, const SectionRange& range)
 {
     _sectionIds = copySpan<Property::MitoNeuriteSectionId>(data._sectionIds, range);
     _relativePathLengths = copySpan<Property::MitoPathLength>(data._relativePathLengths, range);
@@ -232,9 +232,9 @@ MitochondriaPointLevel::MitochondriaPointLevel(
     std::vector<MitoNeuriteSectionId::Type> sectionIds,
     std::vector<MitoPathLength::Type> relativePathLengths,
     std::vector<MitoDiameter::Type> diameters)
-    : _sectionIds(sectionIds)
-    , _relativePathLengths(relativePathLengths)
-    , _diameters(diameters)
+    : _sectionIds(std::move(sectionIds))
+    , _relativePathLengths(std::move(relativePathLengths))
+    , _diameters(std::move(diameters))
 {
     if (_sectionIds.size() != _relativePathLengths.size())
         throw SectionBuilderError(
@@ -289,155 +289,153 @@ Annotation::Annotation(AnnotationType type, uint32_t sectionId,
     int32_t lineNumber)
     : _type(type)
     , _sectionId(sectionId)
-    , _points(points)
+    , _points(std::move(points))
     , _lineNumber(lineNumber)
-    , _details(details)
+    , _details(std::move(details))
 {
 }
 
 template <>
-std::vector<Section::Type>& Properties::get<Section>()
-{
-    return _sectionLevel._sections;
-}
-
-template <>
-const std::vector<Section::Type>& Properties::get<Section>() const
+std::vector<Section::Type>& Properties::get<Section>() noexcept
 {
     return _sectionLevel._sections;
 }
 
 template <>
-std::vector<MitoSection::Type>& Properties::get<MitoSection>()
+const std::vector<Section::Type>& Properties::get<Section>() const noexcept
+{
+    return _sectionLevel._sections;
+}
+
+template <>
+std::vector<MitoSection::Type>& Properties::get<MitoSection>() noexcept
 {
     return _mitochondriaSectionLevel._sections;
 }
 
 template <>
-const std::vector<MitoSection::Type>& Properties::get<MitoSection>() const
+const std::vector<MitoSection::Type>& Properties::get<MitoSection>() const noexcept
 {
     return _mitochondriaSectionLevel._sections;
 }
 
 template <>
-std::vector<MitoNeuriteSectionId::Type>& Properties::get<MitoNeuriteSectionId>()
+std::vector<MitoNeuriteSectionId::Type>& Properties::get<MitoNeuriteSectionId>() noexcept
 {
     return _mitochondriaPointLevel._sectionIds;
 }
 
 template <>
 const std::vector<MitoNeuriteSectionId::Type>&
-    Properties::get<MitoNeuriteSectionId>() const
+    Properties::get<MitoNeuriteSectionId>() const noexcept
 {
     return _mitochondriaPointLevel._sectionIds;
 }
 
 template <>
-std::vector<Point::Type>& Properties::get<Point>()
+const std::vector<Point::Type>& Properties::get<Point>() const noexcept
 {
     return _pointLevel._points;
 }
 template <>
-const std::vector<Point::Type>& Properties::get<Point>() const
+std::vector<Point::Type>& Properties::get<Point>() noexcept
 {
     return _pointLevel._points;
 }
 
 template <>
-std::vector<SectionType::Type>& Properties::get<SectionType>()
+const std::vector<SectionType::Type>& Properties::get<SectionType>() const noexcept
 {
     return _sectionLevel._sectionTypes;
 }
 template <>
-const std::vector<SectionType::Type>& Properties::get<SectionType>() const
+std::vector<SectionType::Type>& Properties::get<SectionType>() noexcept
 {
     return _sectionLevel._sectionTypes;
 }
 
 template <>
-std::vector<Perimeter::Type>& Properties::get<Perimeter>()
+const std::vector<Perimeter::Type>& Properties::get<Perimeter>() const noexcept
 {
     return _pointLevel._perimeters;
 }
 
 template <>
-const std::vector<Perimeter::Type>& Properties::get<Perimeter>() const
+std::vector<Perimeter::Type>& Properties::get<Perimeter>() noexcept
 {
     return _pointLevel._perimeters;
 }
 
 template <>
-std::vector<Diameter::Type>& Properties::get<Diameter>()
+const std::vector<Diameter::Type>& Properties::get<Diameter>() const noexcept
 {
     return _pointLevel._diameters;
 }
 
 template <>
-const std::vector<Diameter::Type>& Properties::get<Diameter>() const
+std::vector<Diameter::Type>& Properties::get<Diameter>() noexcept
 {
     return _pointLevel._diameters;
 }
 
 template <>
-std::vector<MitoDiameter::Type>& Properties::get<MitoDiameter>()
+const std::vector<MitoDiameter::Type>& Properties::get<MitoDiameter>() const noexcept
 {
     return _mitochondriaPointLevel._diameters;
 }
 
 template <>
-const std::vector<MitoDiameter::Type>& Properties::get<MitoDiameter>() const
+std::vector<MitoDiameter::Type>& Properties::get<MitoDiameter>() noexcept
 {
     return _mitochondriaPointLevel._diameters;
 }
 
 template <>
-std::vector<MitoPathLength::Type>& Properties::get<MitoPathLength>()
+const std::vector<MitoPathLength::Type>& Properties::get<MitoPathLength>() const noexcept
 {
     return _mitochondriaPointLevel._relativePathLengths;
 }
 
 template <>
-const std::vector<MitoPathLength::Type>& Properties::get<MitoPathLength>() const
+std::vector<MitoPathLength::Type>& Properties::get<MitoPathLength>() noexcept
 {
     return _mitochondriaPointLevel._relativePathLengths;
 }
 
 template <>
-const std::map<int32_t, std::vector<uint32_t>>& Properties::children<Section>()
+const std::map<int32_t, std::vector<uint32_t>>& Properties::children<Section>() const noexcept
 {
     return _sectionLevel._children;
 }
 
 template <>
 const std::map<int32_t, std::vector<uint32_t>>&
-    Properties::children<MitoSection>()
+    Properties::children<MitoSection>() const noexcept
 {
     return _mitochondriaSectionLevel._children;
 }
 
 std::ostream& operator<<(std::ostream& os, const PointLevel& prop)
 {
-    os << "Point level properties:" << std::endl;
-    os << "Point Diameter"
-       << (prop._perimeters.size() == prop._points.size() ? " Perimeter" : "")
-       << std::endl;
+    os << "Point level properties:\n"
+       << "Point Diameter"
+       << (prop._perimeters.size() == prop._points.size() ? " Perimeter\n" : "\n");
     for (unsigned int i = 0; i < prop._points.size(); ++i) {
         os << dumpPoint(prop._points[i]) << ' ' << prop._diameters[i];
         if (prop._perimeters.size() == prop._points.size())
             os << ' ' << prop._perimeters[i];
-        os << std::endl;
+        os << '\n';
     }
     return os;
 }
 
 std::ostream& operator<<(std::ostream& os, const Properties& properties)
 {
-    os << properties._pointLevel << std::endl;
-    // os << _sectionLevel << std::endl;
-    // os << _cellLevel << std::endl;
+    os << properties._pointLevel << '\n';
+    // os << _sectionLevel << '\n';
+    // os << _cellLevel << '\n';
     return os;
 }
-
 
 } // namespace Property
 } // namespace morphio

--- a/src/readers/lex.cpp
+++ b/src/readers/lex.cpp
@@ -58,8 +58,8 @@ inline std::string to_string(Token t)
 {
     switch (t) {
 #define Q(x) #x
-#define T(TOK)       \
-    case Token::TOK: \
+#define T(TOK)         \
+    case Token::TOK:   \
         return Q(TOK); \
         break;
         T(EOF_)
@@ -94,7 +94,8 @@ inline std::string to_string(Token t)
     }
 }
 
-inline std::ostream& operator<<(std::ostream& ostr, Token t) {
+inline std::ostream& operator<<(std::ostream& ostr, Token t)
+{
     return ostr << to_string(t);
 }
 

--- a/src/readers/morphologyASC.cpp
+++ b/src/readers/morphologyASC.cpp
@@ -85,7 +85,7 @@ private:
     std::tuple<Point, float> parse_point(NeurolucidaLexer& lex)
     {
         lex.expect(Token::LPAREN, "Point should start in LPAREN");
-        std::array<float, 4> point{}; // X,Y,Z,R
+        std::array<float, 4> point {}; // X,Y,Z,R
         for (auto& p : point) {
             try {
                 p = std::stof(lex.consume()->str());

--- a/src/readers/morphologyASC.cpp
+++ b/src/readers/morphologyASC.cpp
@@ -57,7 +57,7 @@ bool skip_sexp(size_t id)
 class NeurolucidaParser
 {
 public:
-    NeurolucidaParser(const std::string& uri)
+    explicit NeurolucidaParser(const std::string& uri)
         : uri_(uri)
         , lex_(uri)
         , debugInfo_(uri)
@@ -85,7 +85,7 @@ private:
     std::tuple<Point, float> parse_point(NeurolucidaLexer& lex)
     {
         lex.expect(Token::LPAREN, "Point should start in LPAREN");
-        std::array<float, 4> point; // X,Y,Z,R
+        std::array<float, 4> point{}; // X,Y,Z,R
         for (auto& p : point) {
             try {
                 p = std::stof(lex.consume()->str());
@@ -104,8 +104,8 @@ private:
 
         lex.consume(Token::RPAREN, "Point should end in RPAREN");
 
-        return std::tuple<Point, float>{{point[0], point[1], point[2]},
-            point[3]};
+        return std::tuple<Point, float>({point[0], point[1], point[2]},
+            point[3]);
     }
 
     bool parse_neurite_branch(int32_t parent_id, Token token)
@@ -135,7 +135,7 @@ private:
         properties._points = points;
         properties._diameters = diameters;
         if (token == Token::CELLBODY) {
-            if (nb_.soma()->points().size() != 0)
+            if (!nb_.soma()->points().empty())
                 throw SomaError(
                     err_.ERROR_SOMA_ALREADY_DEFINED(lex_.line_num()));
             nb_.soma()->properties() = properties;
@@ -206,17 +206,18 @@ private:
     {
         Points points;
         std::vector<float> diameters;
-        int32_t section_id = static_cast<int>(nb_.sections().size());
+        auto section_id = static_cast<int>(nb_.sections().size());
 
         while (true) {
-            const Token id = static_cast<Token>(lex_.current()->id);
+            const auto id = static_cast<Token>(lex_.current()->id);
             const size_t peek_id = lex_.peek()->id;
 
             if (is_eof(id)) {
                 throw RawDataError(err_.ERROR_EOF_IN_NEURITE(lex_.line_num()));
             } else if (is_end_of_section(id)) {
-                if (!points.empty())
+                if (!points.empty()) {
                     _create_soma_or_section(token, parent_id, points, diameters);
+                }
                 return true;
             } else if (is_end_of_branch(id)) {
                 lex_.consume();
@@ -259,10 +260,10 @@ private:
     {
         // parse the top level blocks, and if they are a neurite, otherwise skip
         while (!lex_.ended()) {
-            const Token peek_id = static_cast<Token>(lex_.peek()->id);
+            const auto peek_id = static_cast<Token>(lex_.peek()->id);
             if (is_neurite_type(peek_id)) {
                 lex_.consume(); // Advance to NeuriteType
-                const Token current_id = static_cast<Token>(lex_.current()->id);
+                const auto current_id = static_cast<Token>(lex_.current()->id);
 
                 lex_.consume();
                 lex_.consume(Token::RPAREN, "New Neurite should end in RPAREN");

--- a/src/readers/morphologyHDF5.cpp
+++ b/src/readers/morphologyHDF5.cpp
@@ -81,13 +81,6 @@ Property::Properties MorphologyHDF5::load()
     return _properties;
 }
 
-MorphologyHDF5::~MorphologyHDF5()
-{
-    _points.reset();
-    _sections.reset();
-    _file.reset();
-}
-
 void MorphologyHDF5::_checkVersion(const std::string& source)
 {
     if (_readV11Metadata())

--- a/src/readers/morphologyHDF5.h
+++ b/src/readers/morphologyHDF5.h
@@ -19,7 +19,7 @@ class MorphologyHDF5
 {
 public:
     MorphologyHDF5(const std::string& uri) : _err(uri), _uri(uri){}
-    virtual ~MorphologyHDF5();
+    virtual ~MorphologyHDF5() = default;
     Property::Properties load();
 
 private:

--- a/src/readers/morphologySWC.cpp
+++ b/src/readers/morphologySWC.cpp
@@ -42,7 +42,7 @@ public:
     {
         _readSamples();
 
-        for (auto sample_pair : samples) {
+        for (const auto& sample_pair : samples) {
             const auto& sample = sample_pair.second;
             raiseIfNonConform(sample);
         }
@@ -84,7 +84,6 @@ public:
                 lastSomaPoint = static_cast<int>(sample.id);
             }
         }
-        file.close();
     }
 
     /**
@@ -187,7 +186,7 @@ public:
     }
 
     template <typename T>
-    void appendSample(std::shared_ptr<T> somaOrSection, const Sample& sample)
+    void appendSample(const std::shared_ptr<T>& somaOrSection, const Sample& sample)
     {
         debugInfo.setLineNumber(sample.id, sample.lineNumber);
         somaOrSection->points().push_back(sample.point);

--- a/src/readers/vasculatureHDF5.h
+++ b/src/readers/vasculatureHDF5.h
@@ -23,8 +23,7 @@ public:
     , _uri(uri)
     {}
 
-    virtual ~VasculatureHDF5()
-    {}
+    virtual ~VasculatureHDF5() = default;
 
     vasculature::property::Properties load();
 

--- a/src/section.cpp
+++ b/src/section.cpp
@@ -41,17 +41,17 @@ upstream_iterator Section::upstream_end() const
     return upstream_iterator();
 }
 
-const range<const Point> Section::points() const
+range<const Point> Section::points() const
 {
     return get<Property::Point>();
 }
 
-const range<const float> Section::diameters() const
+range<const float> Section::diameters() const
 {
     return get<Property::Diameter>();
 }
 
-const range<const float> Section::perimeters() const
+range<const float> Section::perimeters() const
 {
     return get<Property::Perimeter>();
 }
@@ -60,7 +60,7 @@ const range<const float> Section::perimeters() const
 
 std::ostream& operator<<(std::ostream& os, const morphio::Section& section)
 {
-    auto points = section.points();
+    const auto& points = section.points();
     if (points.empty())
     {
         os << "Section(id=" << section.id() << ", points=[])";
@@ -75,9 +75,10 @@ std::ostream& operator<<(std::ostream& os, const morphio::Section& section)
 
 // operator<< must be defined in the global namespace to be usable there
 std::ostream& operator<<(std::ostream& os,
-    const morphio::range<const morphio::Point> points)
+    const morphio::range<const morphio::Point>& points)
 {
-    for (auto point : points)
-        os << point[0] << ' ' << point[1] << ' ' << point[2] << std::endl;
+    for (const auto& point : points) {
+        os << point[0] << ' ' << point[1] << ' ' << point[2] << '\n';
+    }
     return os;
 }

--- a/src/soma.cpp
+++ b/src/soma.cpp
@@ -6,12 +6,12 @@
 #include <morphio/vector_types.h>
 
 namespace morphio {
-Soma::Soma(std::shared_ptr<Property::Properties> properties)
+Soma::Soma(const std::shared_ptr<Property::Properties>& properties)
     : _properties(properties)
 {
 }
 
-const Point Soma::center() const
+Point Soma::center() const
 {
     return centerOfGravity(_properties->_somaLevel._points);
 }

--- a/src/vasc/properties.cpp
+++ b/src/vasc/properties.cpp
@@ -12,8 +12,8 @@ namespace vasculature {
 static bool verbose = false;
 namespace property {
 
-VascPointLevel::VascPointLevel(std::vector<Point::Type> points,
-    std::vector<Diameter::Type> diameters)
+VascPointLevel::VascPointLevel(const std::vector<Point::Type>& points,
+    const std::vector<Diameter::Type>& diameters)
     : _points(points)
     , _diameters(diameters)
 {
@@ -203,86 +203,73 @@ bool Properties::operator!=(const Properties& other) const
 }
 
 template <>
-std::vector<VascSection::Type>& Properties::get<VascSection>()
+std::vector<VascSection::Type>& Properties::get<VascSection>() noexcept
 {
     return _sectionLevel._sections;
 }
 
 template <>
-const std::vector<VascSection::Type>& Properties::get<VascSection>() const
+const std::vector<VascSection::Type>& Properties::get<VascSection>() const noexcept
 {
     return _sectionLevel._sections;
 }
 
 template <>
-std::vector<Point::Type>& Properties::get<Point>()
+std::vector<Point::Type>& Properties::get<Point>() noexcept
 {
     return _pointLevel._points;
 }
 
 template <>
-const std::vector<Point::Type>& Properties::get<Point>() const
+const std::vector<Point::Type>& Properties::get<Point>() const noexcept
 {
     return _pointLevel._points;
 }
 
 template <>
-std::vector<Connection::Type>& Properties::get<Connection>()
+std::vector<Connection::Type>& Properties::get<Connection>() noexcept
 {
     return _connectivity;
 }
 
 template <>
-std::vector<SectionType::Type>& Properties::get<SectionType>()
+std::vector<SectionType::Type>& Properties::get<SectionType>() noexcept
 {
     return _sectionLevel._sectionTypes;
 }
 
 template <>
-const std::vector<SectionType::Type>& Properties::get<SectionType>() const
+const std::vector<SectionType::Type>& Properties::get<SectionType>() const noexcept
 {
     return _sectionLevel._sectionTypes;
 }
 
 template <>
-std::vector<Diameter::Type>& Properties::get<Diameter>()
+std::vector<Diameter::Type>& Properties::get<Diameter>() noexcept
 {
     return _pointLevel._diameters;
 }
 
 template <>
-const std::vector<Diameter::Type>& Properties::get<Diameter>() const
+const std::vector<Diameter::Type>& Properties::get<Diameter>() const noexcept
 {
     return _pointLevel._diameters;
-}
-
-const std::map<uint32_t, std::vector<uint32_t>>& Properties::predecessors()
-{
-    return _sectionLevel._predecessors;
-}
-
-const std::map<uint32_t, std::vector<uint32_t>>& Properties::successors()
-{
-    return _sectionLevel._successors;
 }
 
 std::ostream& operator<<(std::ostream& os, const VascPointLevel& prop)
 {
-    os << "Point level properties:" << std::endl;
+    os << "Point level properties:\n";
     os << "Point diameter"
-       << (prop._diameters.size() == prop._points.size() ? " Diameter" : "")
-       << std::endl;
+       << (prop._diameters.size() == prop._points.size() ? " Diameter\n" : "\n");
     for (unsigned int i = 0; i < prop._points.size(); ++i) {
-        os << dumpPoint(prop._points[i]) << ' ' << prop._diameters[i];
-        os << std::endl;
+        os << dumpPoint(prop._points[i]) << ' ' << prop._diameters[i] << '\n';
     }
     return os;
 }
 
 std::ostream& operator<<(std::ostream& os, const Properties& properties)
 {
-    os << properties._pointLevel << std::endl;
-    return os;
+    return os << properties._pointLevel << '\n';
 }
 } // namespace property
 } // namespace vasculature

--- a/src/vasc/section.cpp
+++ b/src/vasc/section.cpp
@@ -25,7 +25,7 @@ Section::Section(const uint32_t id_,
 
     if (_range.second <= _range.first)
         std::cerr << "Dereferencing broken properties section " << _id
-            << "\nSection range: " << _range.first << " -> " << _range.second << '\n';
+                  << "\nSection range: " << _range.first << " -> " << _range.second << '\n';
 }
 
 Section& Section::operator=(const Section& section)

--- a/src/vasc/section.cpp
+++ b/src/vasc/section.cpp
@@ -48,7 +48,7 @@ bool Section::operator!=(const Section& other) const
     return !(*this == other);
 }
 
-uint32_t Section::id() const
+uint32_t Section::id() const noexcept
 {
     return _id;
 }
@@ -57,8 +57,9 @@ template <typename TProperty>
 range<const typename TProperty::Type> Section::get() const
 {
     auto& data = _properties->get<TProperty>();
-    if (data.empty())
+    if (data.empty()) {
         return range<const typename TProperty::Type>();
+    }
     auto ptr_start = data.data() + _range.first;
     return range<const typename TProperty::Type>(ptr_start,
         _range.second - _range.first);
@@ -67,29 +68,27 @@ range<const typename TProperty::Type> Section::get() const
 std::vector<Section> Section::predecessors() const
 {
     std::vector<Section> result;
-    try {
-        const std::vector<uint32_t>& predecessors_ = _properties->predecessors().at(_id);
-        result.reserve(predecessors_.size());
-        for (const uint32_t id_ : predecessors_)
+    const auto it = _properties->predecessors().find(_id);
+    if (it != _properties->predecessors().end()) {
+        result.reserve(it->second.size());
+        for (const uint32_t id_ : it->second) {
             result.emplace_back(id_, _properties);
-        return result;
-    } catch (...){
-        return result;
+        }
     }
+    return result;
 }
 
 std::vector<Section> Section::successors() const
 {
     std::vector<Section> result;
-    try {
-        const std::vector<uint32_t>& successors_ = _properties->successors().at(_id);
-        result.reserve(successors_.size());
-        for (const uint32_t id_ : successors_)
+    const auto it = _properties->successors().find(_id);
+    if (it != _properties->successors().end()) {
+        result.reserve(it->second.size());
+        for (const uint32_t id_ : it->second) {
             result.emplace_back(id_, _properties);
-        return result;
-    } catch (...) {
-        return result;
+        }
     }
+    return result;
 }
 
 std::vector<Section> Section::neighbors() const

--- a/src/vasc/section.cpp
+++ b/src/vasc/section.cpp
@@ -6,7 +6,7 @@ namespace vasculature {
 using graph_iterator = graph_iterator_t<Section, Vasculature>;
 
 Section::Section(const uint32_t id_,
-    std::shared_ptr<property::Properties> properties)
+    const std::shared_ptr<property::Properties>& properties)
     : _id(id_)
     , _properties(properties)
 {
@@ -24,18 +24,11 @@ Section::Section(const uint32_t id_,
     _range = std::make_pair(start, end_);
 
     if (_range.second <= _range.first)
-        std::cerr << "Dereferencing broken properties section " << _id << std::endl
-            << "Section range: " << _range.first << " -> " << _range.second << std::endl;
+        std::cerr << "Dereferencing broken properties section " << _id
+            << "\nSection range: " << _range.first << " -> " << _range.second << '\n';
 }
 
-Section::Section(const Section& section)
-    : _id(section._id)
-    , _range(section._range)
-    , _properties(section._properties)
-{
-}
-
-const Section& Section::operator=(const Section& section)
+Section& Section::operator=(const Section& section)
 {
     if (&section == this)
         return *this;
@@ -61,7 +54,7 @@ uint32_t Section::id() const
 }
 
 template <typename TProperty>
-const range<const typename TProperty::Type> Section::get() const
+range<const typename TProperty::Type> Section::get() const
 {
     auto& data = _properties->get<TProperty>();
     if (data.empty())
@@ -71,41 +64,40 @@ const range<const typename TProperty::Type> Section::get() const
         _range.second - _range.first);
 }
 
-const std::vector<Section> Section::predecessors() const
+std::vector<Section> Section::predecessors() const
 {
     std::vector<Section> result;
     try {
         const std::vector<uint32_t>& predecessors_ = _properties->predecessors().at(_id);
         result.reserve(predecessors_.size());
         for (const uint32_t id_ : predecessors_)
-            result.push_back(Section(id_, _properties));
+            result.emplace_back(id_, _properties);
         return result;
     } catch (...){
         return result;
     }
 }
 
-const std::vector<Section> Section::successors() const
+std::vector<Section> Section::successors() const
 {
     std::vector<Section> result;
     try {
         const std::vector<uint32_t>& successors_ = _properties->successors().at(_id);
         result.reserve(successors_.size());
         for (const uint32_t id_ : successors_)
-            result.push_back(Section(id_, _properties));
+            result.emplace_back(id_, _properties);
         return result;
     } catch (...) {
         return result;
     }
 }
 
-const std::vector<Section> Section::neighbors() const
+std::vector<Section> Section::neighbors() const
 {
-    std::vector<Section> pre = this->predecessors();
-    std::vector<Section> suc = this->successors();
-    for (size_t i = 0; i < suc.size(); ++i) {
-        pre.push_back(suc[i]);
-    }
+    auto pre = this->predecessors();
+    const auto& suc = this->successors();
+    pre.reserve(pre.size() + suc.size());
+    std::copy(suc.begin(), suc.end(), std::back_inserter(pre));
     return pre;
 }
 
@@ -117,7 +109,7 @@ VascularSectionType Section::type() const
 
 float Section::length() const
 {
-    auto points_ = this->points();
+    const auto& points_ = this->points();
     if (points_.size() < 2)
         return 0;
 
@@ -125,12 +117,12 @@ float Section::length() const
     return distance(points_[0], points_[last]);
 }
 
-const range<const Point> Section::points() const
+range<const Point> Section::points() const
 {
     return get<property::Point>();
 }
 
-const range<const float> Section::diameters() const
+range<const float> Section::diameters() const
 {
     return get<property::Diameter>();
 }

--- a/src/vasc/vasculature.cpp
+++ b/src/vasc/vasculature.cpp
@@ -53,27 +53,6 @@ std::vector<Section> Vasculature::sections() const
     return sections_;
 }
 
-template <typename Property>
-const std::vector<typename Property::Type>& Vasculature::get() const noexcept
-{
-    return _properties->get<Property>();
-}
-
-const Points& Vasculature::points() const noexcept
-{
-    return get<property::Point>();
-}
-
-const std::vector<float>& Vasculature::diameters() const noexcept
-{
-    return get<property::Diameter>();
-}
-
-const std::vector<property::SectionType::Type>& Vasculature::sectionTypes() const noexcept
-{
-    return get<property::SectionType>();
-}
-
 graph_iterator Vasculature::begin() const
 {
     return graph_iterator(*this);
@@ -87,12 +66,12 @@ graph_iterator Vasculature::end() const
 void buildConnectivity(std::shared_ptr<property::Properties> properties)
 {
     const std::vector<std::array<unsigned int, 2>>& connectivity = properties->get<property::Connection>();
-    std::map<uint32_t, std::vector<uint32_t>>& successors = properties->_sectionLevel._successors;
-    std::map<uint32_t, std::vector<uint32_t>>& predecessors = properties->_sectionLevel._predecessors;
+    auto& successors = properties->_sectionLevel._successors;
+    auto& predecessors = properties->_sectionLevel._predecessors;
 
-    for (size_t i = 0; i < connectivity.size(); ++i) {
-        uint32_t first = connectivity[i][0];
-        uint32_t second = connectivity[i][1];
+    for (const auto& connection : connectivity) {
+        uint32_t first = connection[0];
+        uint32_t second = connection[1];
         successors[first].push_back(second);
         predecessors[second].push_back(first);
     }

--- a/src/vasc/vasculature.cpp
+++ b/src/vasc/vasculature.cpp
@@ -37,37 +37,39 @@ Vasculature::Vasculature(const std::string& source)
     buildConnectivity(_properties);
 }
 
-const Section Vasculature::section(const uint32_t& id) const
+Section Vasculature::section(const uint32_t& id) const
 {
-    return Section(id, _properties);
+    return {id, _properties};
 }
 
-const std::vector<Section> Vasculature::sections() const
+std::vector<Section> Vasculature::sections() const
 {
     std::vector<Section> sections_;
-    for (size_t i = 0; i < _properties->get<property::VascSection>().size(); ++i) {
-        sections_.push_back(section(static_cast<uint32_t>(i)));
+    const auto& vasc_sections = _properties->get<property::VascSection>();
+    sections_.reserve(vasc_sections.size());
+    for (size_t i = 0; i < vasc_sections.size(); ++i) {
+        sections_.emplace_back(static_cast<uint32_t>(i), _properties);
     }
     return sections_;
 }
 
 template <typename Property>
-const std::vector<typename Property::Type>& Vasculature::get() const
+const std::vector<typename Property::Type>& Vasculature::get() const noexcept
 {
     return _properties->get<Property>();
 }
 
-const Points& Vasculature::points() const
+const Points& Vasculature::points() const noexcept
 {
     return get<property::Point>();
 }
 
-const std::vector<float>& Vasculature::diameters() const
+const std::vector<float>& Vasculature::diameters() const noexcept
 {
     return get<property::Diameter>();
 }
 
-const std::vector<property::SectionType::Type>& Vasculature::sectionTypes() const
+const std::vector<property::SectionType::Type>& Vasculature::sectionTypes() const noexcept
 {
     return get<property::SectionType>();
 }

--- a/src/vector_utils.cpp
+++ b/src/vector_utils.cpp
@@ -99,7 +99,7 @@ std::string dumpPoints(const Points& points)
 }
 
 template <typename T>
-const Point centerOfGravity(const T& points)
+Point centerOfGravity(const T& points)
 {
     float x = 0, y = 0, z = 0;
     float size = float(points.size());
@@ -110,8 +110,8 @@ const Point centerOfGravity(const T& points)
     }
     return Point({x / size, y / size, z / size});
 }
-template const Point centerOfGravity(const range<const Point>& points);
-template const Point centerOfGravity(const Points& points);
+template Point centerOfGravity(const range<const Point>& points);
+template Point centerOfGravity(const Points& points);
 
 template <typename T>
 float maxDistanceToCenterOfGravity(const T& points)

--- a/src/vector_utils.cpp
+++ b/src/vector_utils.cpp
@@ -10,7 +10,7 @@ namespace morphio {
 Point operator+(const Point& left, const Point& right)
 {
     Point ret;
-    for (size_t i = 0; i < 3; ++i)
+    for (size_t i = 0; i < ret.size(); ++i)
         ret[i] = left[i] + right[i];
     return ret;
 }
@@ -18,28 +18,28 @@ Point operator+(const Point& left, const Point& right)
 Point operator-(const Point& left, const Point& right)
 {
     Point ret;
-    for (size_t i = 0; i < 3; ++i)
+    for (size_t i = 0; i < ret.size(); ++i)
         ret[i] = left[i] - right[i];
     return ret;
 }
 
 Point operator+=(Point& left, const Point& right)
 {
-    for (size_t i = 0; i < 3; ++i)
+    for (size_t i = 0; i < left.size(); ++i)
         left[i] += right[i];
     return left;
 }
 
 Point operator-=(Point& left, const Point& right)
 {
-    for (size_t i = 0; i < 3; ++i)
+    for (size_t i = 0; i < left.size(); ++i)
         left[i] -= right[i];
     return left;
 }
 
 Point operator/=(Point& left, float factor)
 {
-    for (size_t i = 0; i < 3; ++i)
+    for (size_t i = 0; i < left.size(); ++i)
         left[i] /= factor;
     return left;
 }
@@ -85,25 +85,26 @@ float distance(const Point& left, const Point& right)
 
 std::string dumpPoint(const Point& point)
 {
-    std::stringstream ss;
-    ss << point[0] << " " << point[1] << " " << point[2];
-    return ss.str();
+    std::ostringstream oss;
+    oss << point[0] << " " << point[1] << " " << point[2];
+    return oss.str();
 }
 
 std::string dumpPoints(const Points& points)
 {
-    std::string str;
-    for (const auto& point : points)
-        str += dumpPoint(point) + "\n";
-    return str;
+    std::ostringstream oss;
+    for (const auto& point : points) {
+        oss << dumpPoint(point) << '\n';
+    }
+    return oss.str();
 }
 
 template <typename T>
 Point centerOfGravity(const T& points)
 {
-    float x = 0, y = 0, z = 0;
-    float size = float(points.size());
-    for (const Point& point : points) {
+    Point::value_type x = 0, y = 0, z = 0;
+    const auto size = static_cast<Point::value_type>(points.size());
+    for (const auto& point : points) {
         x += point[0];
         y += point[1];
         z += point[2];
@@ -131,8 +132,9 @@ template <typename T>
 Point operator*(const Point& from, T factor)
 {
     Point ret;
-    for (size_t i = 0; i < 3; ++i)
-        ret[i] = from[i] * static_cast<float>(factor);
+    for (size_t i = 0; i < ret.size(); ++i) {
+        ret[i] = from[i] * static_cast<Point::value_type>(factor);
+    }
     return ret;
 }
 template Point operator*<int>(const Point& from, int factor);
@@ -156,14 +158,12 @@ template Point operator/(const Point& from, float factor);
 
 std::ostream& operator<<(std::ostream& os, const Points& points)
 {
-    os << morphio::dumpPoints(points);
-    return os;
+    return os << morphio::dumpPoints(points);
 }
 
 std::ostream& operator<<(std::ostream& os, const morphio::Point& point)
 {
-    os << morphio::dumpPoint(point);
-    return os;
+    return os << morphio::dumpPoint(point);
 }
 
 // Like std::tolower but accepts char
@@ -176,11 +176,9 @@ char my_tolower(char ch)
 
 std::ostream& operator<<(std::ostream& os, const morphio::Points& points)
 {
-    os << morphio::dumpPoints(points);
-    return os;
+    return os << morphio::dumpPoints(points);
 }
 std::ostream& operator<<(std::ostream& os, const morphio::Point& point)
 {
-    os << morphio::dumpPoint(point);
-    return os;
+    return os << morphio::dumpPoint(point);
 }


### PR DESCRIPTION
* Never return constant lvalue, only lvalue, as the returned object
  is owned by the caller.
* Use constant rvalue instead of lvalue for non-integral types i.e
* Use lvalue instead of rvalue for arguments with integral type.
* Use `std::move` to initialize fields in constructors.
* Mark `explicit` constructors taking only one argument.
* Assignment operator should return a rvalue, not a constant rvalue.
* Move constructor must have `noexcept` specifier to be leveraged.
* Add `noexcept` and `const` specifiers to member methods when relevant.
* Inline member variable accessors.
* Let `shared_ptr` use the standard destructor of the wrapped object, see #121
* Use `default=` implementation of constructors and destructors when relevant.
* Use `auto` instead of repeating the type in variable definitions using
  casts like below:
   ```
   auto var = static_cast<T>(...);
   ```
* Increase readability of escaped strings by using raw string literals.
* Use range-base loop when possible.
* Reduce copies by using `auto&` and `const auto&`, especialy in for-loops.
* Use '\n' instead of `std::endl` to prevent unnecessary flush of data.
* parameter names of both function definitions and declarations must be consistent.
* STL:
  * use `Container::empty()` instead of `Container::size() == 0`.
  * use `std::vector::emplace_back` when possible. See #123 for future improvements.
  * use `std::vector::reserve` when possible.
  * use `std::vector::front` and `std::vector::back`.
  * use `std::make_shared` instead of using allocator explicitely.
  * use `std::copy(begin, end, std::back_inserter)` pattern
  * use `std::ostringstream` instead of `std::string` concatenation.
  * Do not call `std::fstream::close` explicitely.
* custom iterator classes:
  * classes extends `std::iterator`
  * `operator*` returns a lvalue.
  * `operator++()` returns a lvalue.
* Use uniform initialization in `return` statement to prevent repeating the type name
  unless constructor is marked `explicit`.
* Put single then or else statement around braces.