### PR TITLE
cmake: tell dependents about header locations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ option(${PROJECT_NAME}_CXX_WARNINGS "Compile C++ with warnings" ON)
 include(${PROJECT_SOURCE_DIR}/CMake/CompilerFlags.cmake)
 set(CMAKE_CXX_FLAGS "${FLAGS}")
 
-set(MORPHIO_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/include)
+set(MORPHIO_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/include/)
 
 add_subdirectory(3rdparty)
 add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -86,6 +86,7 @@ foreach(TARGET morphio_shared morphio_static)
     SYSTEM
     PUBLIC
      $<BUILD_INTERFACE:${MORPHIO_INCLUDE_DIR}>
+     $<INSTALL_INTERFACE:include>
      $<TARGET_PROPERTY:gsl-lite,INTERFACE_INCLUDE_DIRECTORIES>
     PRIVATE
      $<TARGET_PROPERTY:HighFive,INTERFACE_INCLUDE_DIRECTORIES>
@@ -99,5 +100,4 @@ install(
   TARGETS morphio_shared
   EXPORT MorphIOTargets
   LIBRARY DESTINATION lib
-  PUBLIC_HEADER DESTINATION include
   )


### PR DESCRIPTION
The installed `MorphIOTargets.cmake` should point to the header directory and tie it in with `-isystem` for dependents with this.