### PR TITLE
Lower minimum C++ version to 11 in tests/CMakeLists.txt

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ add_executable(unittests ${TESTS_SRC})
 
 set_target_properties(unittests
   PROPERTIES
-  CXX_STANDARD 14
+  CXX_STANDARD 11
   CXX_STANDARD_REQUIRED YES
   CXX_EXTENSIONS NO
   )


### PR DESCRIPTION
Issue #133

As explained there, it was agreed to keep C++ 11 compatibility