### PR TITLE
Remove declaration of MitoSection::type

### DIFF
--- a/include/morphio/mito_section.h
+++ b/include/morphio/mito_section.h
@@ -54,9 +54,6 @@ public:
      **/
     range<const float> relativePathLengths() const;
 
-    /** Return the morphological type of this section (dendrite, axon, ...). */
-    SectionType type() const;
-
 protected:
     MitoSection(uint32_t id_, const std::shared_ptr<Property::Properties>& morphology)
         : SectionBase(id_, morphology)


### PR DESCRIPTION
as there was no definition and the mitochondria has no type anyway
https://bbpteam.epfl.ch/documentation/projects/Morphology%20Documentation/latest/h5v1.html

Issue #122