### PR TITLE
Mutate by index

### DIFF
--- a/binds/python/bind_mutable.cpp
+++ b/binds/python/bind_mutable.cpp
@@ -245,9 +245,6 @@ void bind_mutable_module(py::module& m) {
             "at each root section",
             "section_id"_a = -1);
 
-    using mitosection_floats_f = std::vector<float>& (morphio::mut::MitoSection::*) ();
-    using mitosection_ints_f = std::vector<uint32_t>& (morphio::mut::MitoSection::*) ();
-
     // py::nodelete needed because morphio::mut::MitoSection has a private
     // destructor
     // http://pybind11.readthedocs.io/en/stable/advanced/classes.html?highlight=private%20destructor#non-public-destructors
@@ -341,8 +338,7 @@ void bind_mutable_module(py::module& m) {
         .def_property("points",
                       [](py::object &obj){
                           auto& section = obj.cast<morphio::mut::Section&>();
-                          std::vector<long int> strides{static_cast<py::size_t>(sizeof(float) * 3),
-                                                        static_cast<py::size_t>(sizeof(float))};
+                          std::vector<long int> strides{sizeof(float) * 3, sizeof(float)};
                           std::vector<long int> shape{static_cast<py::ssize_t>(section.points().size()), 3};
 
                           return py::array_t<float>(shape,

--- a/binds/python/bind_mutable.cpp
+++ b/binds/python/bind_mutable.cpp
@@ -254,25 +254,42 @@ void bind_mutable_module(py::module& m) {
     py::class_<morphio::mut::MitoSection, std::shared_ptr<morphio::mut::MitoSection>>(m,
                                                                                       "MitoSection")
         .def_property_readonly("id", &morphio::mut::MitoSection::id, "Return the section ID")
-        .def_property(
-            "diameters",
-            static_cast<mitosection_floats_f>(&morphio::mut::MitoSection::diameters),
-            [](morphio::mut::MitoSection* section, const std::vector<float>& _diameters) {
+        .def_property("diameters",
+                      [](py::object &obj){
+                          auto& section = obj.cast<morphio::mut::MitoSection&>();
+                          return py::array_t<float>({static_cast<py::ssize_t>(section.diameters().size())},
+                                                    {sizeof(float)},
+                                                    section.diameters().data(),
+                                                    obj);
+                      },
+            [](morphio::mut::MitoSection* section,
+                const std::vector<float>& _diameters) {
                 section->diameters() = _diameters;
             },
             "Returns the diameters of all points of this section")
-        .def_property(
-            "relative_path_lengths",
-            static_cast<mitosection_floats_f>(&morphio::mut::MitoSection::pathLengths),
-            [](morphio::mut::MitoSection* section, const std::vector<float>& _pathLengths) {
+        .def_property("relative_path_lengths",
+                      [](py::object &obj){
+                          auto& section = obj.cast<morphio::mut::MitoSection&>();
+                          return py::array_t<float>({static_cast<py::ssize_t>(section.pathLengths().size())},
+                                                    {sizeof(float)},
+                                                    section.pathLengths().data(),
+                                                    obj);
+                      },
+            [](morphio::mut::MitoSection* section,
+                const std::vector<float>& _pathLengths) {
                 section->pathLengths() = _pathLengths;
             },
             "Returns the relative distance (between 0 and 1)\n"
             "between the start of the neuronal section and each point\n"
             "of this mitochondrial section")
-        .def_property(
-            "neurite_section_ids",
-            static_cast<mitosection_ints_f>(&morphio::mut::MitoSection::neuriteSectionIds),
+        .def_property("neurite_section_ids",
+                      [](py::object &obj){
+                          auto& section = obj.cast<morphio::mut::MitoSection&>();
+                          return py::array_t<uint32_t>({static_cast<py::ssize_t>(section.neuriteSectionIds().size())},
+                                                       {sizeof(uint32_t)},
+                                                       section.neuriteSectionIds().data(),
+                                                       obj);
+                      },
             [](morphio::mut::MitoSection* section,
                const std::vector<uint32_t>& _neuriteSectionIds) {
                 section->neuriteSectionIds() = _neuriteSectionIds;
@@ -321,36 +338,49 @@ void bind_mutable_module(py::module& m) {
             },
             "Returns the morphological type of this section "
             "(dendrite, axon, ...)")
-        .def_property(
-            "points",
-            [](morphio::mut::Section* section) {
-                return py::array(static_cast<py::ssize_t>(section->points().size()),
-                                 section->points().data());
-            },
-            [](morphio::mut::Section* section, py::array_t<float> _points) {
-                section->points() = array_to_points(_points);
-            },
-            "Returns the coordinates (x,y,z) of all points of this section")
-        .def_property(
-            "diameters",
-            [](morphio::mut::Section* section) {
-                return py::array(static_cast<py::ssize_t>(section->diameters().size()),
-                                 section->diameters().data());
-            },
-            [](morphio::mut::Section* section, py::array_t<float> _diameters) {
-                section->diameters() = _diameters.cast<std::vector<float>>();
-            },
-            "Returns the diameters of all points of this section")
-        .def_property(
-            "perimeters",
-            [](morphio::mut::Section* section) {
-                return py::array(static_cast<py::ssize_t>(section->perimeters().size()),
-                                 section->perimeters().data());
-            },
-            [](morphio::mut::Section* section, py::array_t<float> _perimeters) {
-                section->perimeters() = _perimeters.cast<std::vector<float>>();
-            },
-            "Returns the perimeters of all points of this section")
+        .def_property("points",
+                      [](py::object &obj){
+                          auto& section = obj.cast<morphio::mut::Section&>();
+                          std::vector<long int> strides{static_cast<py::size_t>(sizeof(float) * 3),
+                                                        static_cast<py::size_t>(sizeof(float))};
+                          std::vector<long int> shape{static_cast<py::ssize_t>(section.points().size()), 3};
+
+                          return py::array_t<float>(shape,
+                                                    strides,
+                                                    static_cast<const float*>(section.points().front().data()),
+                                                    obj);
+                      },
+                      [](morphio::mut::Section* section,
+                         py::array_t<float> _points) {
+                          section -> points() = array_to_points(_points);
+                      },
+                      "Returns the coordinates (x,y,z) of all points of this section")
+        .def_property("diameters",
+             [](py::object &obj){
+                 auto& section = obj.cast<morphio::mut::Section&>();
+                 return py::array_t<float>({static_cast<py::ssize_t>(section.diameters().size())},
+                                           {sizeof(float)},
+                                  section.diameters().data(),
+                                  obj);
+             },
+                      [](morphio::mut::Section* section,
+                         py::array_t<float> _diameters) {
+                          section -> diameters() = _diameters.cast<std::vector<float>>();
+                      },
+                      "Returns the diameters of all points of this section")
+        .def_property("perimeters",
+                      [](py::object &obj){
+                          auto& section = obj.cast<morphio::mut::Section&>();
+                          return py::array_t<float>({static_cast<py::ssize_t>(section.perimeters().size())},
+                                                    {sizeof(float)},
+                                                    section.perimeters().data(),
+                                                    obj);
+                      },
+                      [](morphio::mut::Section* section,
+                         py::array_t<float> _perimeters) {
+                          section -> perimeters() = _perimeters.cast<std::vector<float>>();
+                      },
+                      "Returns the perimeters of all points of this section")
         .def_property_readonly("is_root",
                                &morphio::mut::Section::isRoot,
                                "Return True if section is a root section")

--- a/binds/python/bind_mutable.cpp
+++ b/binds/python/bind_mutable.cpp
@@ -343,7 +343,7 @@ void bind_mutable_module(py::module& m) {
 
                           return py::array_t<float>(shape,
                                                     strides,
-                                                    static_cast<const float*>(section.points().front().data()),
+                                                    section.points().front().data(),
                                                     obj);
                       },
                       [](morphio::mut::Section* section,

--- a/binds/python/bind_mutable.cpp
+++ b/binds/python/bind_mutable.cpp
@@ -254,10 +254,7 @@ void bind_mutable_module(py::module& m) {
         .def_property("diameters",
                       [](py::object &obj){
                           auto& section = obj.cast<morphio::mut::MitoSection&>();
-                          return py::array_t<float>({static_cast<py::ssize_t>(section.diameters().size())},
-                                                    {sizeof(float)},
-                                                    section.diameters().data(),
-                                                    obj);
+                          return as_pyarray(section.diameters(), obj);
                       },
             [](morphio::mut::MitoSection* section,
                 const std::vector<float>& _diameters) {
@@ -267,10 +264,7 @@ void bind_mutable_module(py::module& m) {
         .def_property("relative_path_lengths",
                       [](py::object &obj){
                           auto& section = obj.cast<morphio::mut::MitoSection&>();
-                          return py::array_t<float>({static_cast<py::ssize_t>(section.pathLengths().size())},
-                                                    {sizeof(float)},
-                                                    section.pathLengths().data(),
-                                                    obj);
+                          return as_pyarray(section.pathLengths(), obj);
                       },
             [](morphio::mut::MitoSection* section,
                 const std::vector<float>& _pathLengths) {
@@ -282,10 +276,7 @@ void bind_mutable_module(py::module& m) {
         .def_property("neurite_section_ids",
                       [](py::object &obj){
                           auto& section = obj.cast<morphio::mut::MitoSection&>();
-                          return py::array_t<uint32_t>({static_cast<py::ssize_t>(section.neuriteSectionIds().size())},
-                                                       {sizeof(uint32_t)},
-                                                       section.neuriteSectionIds().data(),
-                                                       obj);
+                          return as_pyarray(section.neuriteSectionIds(), obj);
                       },
             [](morphio::mut::MitoSection* section,
                const std::vector<uint32_t>& _neuriteSectionIds) {
@@ -354,10 +345,7 @@ void bind_mutable_module(py::module& m) {
         .def_property("diameters",
              [](py::object &obj){
                  auto& section = obj.cast<morphio::mut::Section&>();
-                 return py::array_t<float>({static_cast<py::ssize_t>(section.diameters().size())},
-                                           {sizeof(float)},
-                                  section.diameters().data(),
-                                  obj);
+                 return as_pyarray(section.diameters(), obj);
              },
                       [](morphio::mut::Section* section,
                          py::array_t<float> _diameters) {
@@ -367,10 +355,7 @@ void bind_mutable_module(py::module& m) {
         .def_property("perimeters",
                       [](py::object &obj){
                           auto& section = obj.cast<morphio::mut::Section&>();
-                          return py::array_t<float>({static_cast<py::ssize_t>(section.perimeters().size())},
-                                                    {sizeof(float)},
-                                                    section.perimeters().data(),
-                                                    obj);
+                          return as_pyarray(section.perimeters(), obj);
                       },
                       [](morphio::mut::Section* section,
                          py::array_t<float> _perimeters) {

--- a/binds/python/bindings_utils.h
+++ b/binds/python/bindings_utils.h
@@ -47,3 +47,11 @@ inline py::array_t<typename Sequence::value_type> as_pyarray(Sequence&& seq) {
                      capsule           // numpy array references this parent
     );
 }
+
+template <typename Sequence, typename PyObj>
+inline py::array_t<typename Sequence::value_type> as_pyarray(Sequence& seq, PyObj& ref) {
+    return py::array_t<float>({static_cast<py::ssize_t>(seq.size())},
+                              {sizeof(typename Sequence::value_type)},
+                              seq.data(),
+                              ref);
+}

--- a/binds/python/bindings_utils.h
+++ b/binds/python/bindings_utils.h
@@ -50,8 +50,8 @@ inline py::array_t<typename Sequence::value_type> as_pyarray(Sequence&& seq) {
 
 template <typename Sequence, typename PyObj>
 inline py::array_t<typename Sequence::value_type> as_pyarray(Sequence& seq, PyObj& ref) {
-    return py::array_t<float>({static_cast<py::ssize_t>(seq.size())},
-                              {sizeof(typename Sequence::value_type)},
-                              seq.data(),
-                              ref);
+    return py::array_t<typename Sequence::value_type>({static_cast<py::ssize_t>(seq.size())},
+                                                      {sizeof(typename Sequence::value_type)},
+                                                      seq.data(),
+                                                      ref);
 }

--- a/tests/test_5_mut.py
+++ b/tests/test_5_mut.py
@@ -407,6 +407,8 @@ def test_mutate_properties():
     section.diameters = [18]
     assert_array_equal(section.diameters, [18])
 
+    section.points = np.empty((3))
+
 
 def test_mutate_mito_properties():
     morpho = Morphology(os.path.join(_path, "h5/v1/mitochondria.h5"))
@@ -416,9 +418,18 @@ def test_mutate_mito_properties():
     section.diameters[0] = 14
     assert_array_equal(section.diameters, [14, 30, 40, 50])
 
+    with assert_raises(IndexError):
+        section.diameters[4] = 2
+
     # Test mutate the whole diamters array
     section.diameters = [18]
     assert_array_equal(section.diameters, [18])
+
+    # Set to empty
+    section.diameters = np.empty((0, 3))
+    assert_array_equal(section.diameters, [])
+    with assert_raises(IndexError):
+        section.diameters[0] = 2
 
     # Test mutate single neurite section id
     section.neurite_section_ids[0] = 14

--- a/tests/test_5_mut.py
+++ b/tests/test_5_mut.py
@@ -385,3 +385,53 @@ def test_section___str__():
 def test_from_pathlib():
     neuron = Morphology(Path(_path, "simple.asc"))
     assert_equal(len(neuron.root_sections), 2)
+
+def test_mutate_properties():
+    neuron = Morphology(Path(_path, "simple.asc"))
+    section = neuron.section(1)
+
+    # Test mutate a single point
+    section.points[0] = [1, 1, 1]
+    assert_array_equal(section.points, [[1, 1, 1], [-5, 5, 0]])
+
+    # Test mutate the whole points array
+    section.points = [[3, 3, 3], [1, 1, 1], [2, 2, 2]]
+    assert_array_equal(section.points,
+                       [[3, 3, 3], [1, 1, 1], [2, 2, 2]])
+
+    # Test mutate single diameter
+    section.diameters[0] = 14
+    assert_array_equal(section.diameters, [14, 3])
+
+    # Test mutate the whole diamters array
+    section.diameters = [18]
+    assert_array_equal(section.diameters, [18])
+
+
+def test_mutate_mito_properties():
+    morpho = Morphology(os.path.join(_path, "h5/v1/mitochondria.h5"))
+    section = morpho.mitochondria.section(1)
+
+    # Test mutate single diameter
+    section.diameters[0] = 14
+    assert_array_equal(section.diameters, [14, 30, 40, 50])
+
+    # Test mutate the whole diamters array
+    section.diameters = [18]
+    assert_array_equal(section.diameters, [18])
+
+    # Test mutate single neurite section id
+    section.neurite_section_ids[0] = 14
+    assert_array_equal(section.neurite_section_ids, [14, 4, 4, 5])
+
+    # Test mutate the whole neurite section id array
+    section.neurite_section_ids = [18]
+    assert_array_equal(section.neurite_section_ids, [18])
+
+    # Test mutate single relative path length
+    section.relative_path_lengths[0] = 14
+    assert_array_equal(section.relative_path_lengths, np.array([14, 0.7, 0.8, 0.9], dtype=np.float32))
+
+    # Test mutate the whole relative path length array
+    section.relative_path_lengths = [18]
+    assert_array_equal(section.relative_path_lengths, [18])

--- a/tests/test_5_mut.py
+++ b/tests/test_5_mut.py
@@ -399,6 +399,15 @@ def test_mutate_properties():
     assert_array_equal(section.points,
                        [[3, 3, 3], [1, 1, 1], [2, 2, 2]])
 
+    with assert_raises(IndexError):
+        section.points[3] = [0, 0, 0]
+
+    # Set to empty
+    section.points = np.empty((0, 3))
+    assert_array_equal(section.points, np.empty((0, 3)))
+    with assert_raises(IndexError):
+        section.points[0] = [0, 0, 0]
+
     # Test mutate single diameter
     section.diameters[0] = 14
     assert_array_equal(section.diameters, [14, 3])
@@ -406,9 +415,6 @@ def test_mutate_properties():
     # Test mutate the whole diamters array
     section.diameters = [18]
     assert_array_equal(section.diameters, [18])
-
-    section.points = np.empty((3))
-
 
 def test_mutate_mito_properties():
     morpho = Morphology(os.path.join(_path, "h5/v1/mitochondria.h5"))
@@ -418,18 +424,9 @@ def test_mutate_mito_properties():
     section.diameters[0] = 14
     assert_array_equal(section.diameters, [14, 30, 40, 50])
 
-    with assert_raises(IndexError):
-        section.diameters[4] = 2
-
     # Test mutate the whole diamters array
     section.diameters = [18]
     assert_array_equal(section.diameters, [18])
-
-    # Set to empty
-    section.diameters = np.empty((0, 3))
-    assert_array_equal(section.diameters, [])
-    with assert_raises(IndexError):
-        section.diameters[0] = 2
 
     # Test mutate single neurite section id
     section.neurite_section_ids[0] = 14

--- a/tests/test_5_mut.py
+++ b/tests/test_5_mut.py
@@ -399,6 +399,11 @@ def test_mutate_properties():
     assert_array_equal(section.points,
                        [[3, 3, 3], [1, 1, 1], [2, 2, 2]])
 
+    # Test mutate with numpy indexing
+    section.points[[0, 2]] = [4, 4, 4]
+    assert_array_equal(section.points,
+                       [[4, 4, 4], [1, 1, 1], [4, 4, 4]])
+
     with assert_raises(IndexError):
         section.points[3] = [0, 0, 0]
 

--- a/tests/test_5_mut.py
+++ b/tests/test_5_mut.py
@@ -407,6 +407,13 @@ def test_mutate_properties():
     with assert_raises(IndexError):
         section.points[3] = [0, 0, 0]
 
+    # Test that assigning from an existing array produces a copy
+    a = np.array([[10, 10, 10], [20, 20, 20]])
+    section.points = a
+    assert_array_equal(section.points, [[10, 10, 10], [20, 20, 20]])
+    a[0] = [0, 0, 0]
+    assert_array_equal(section.points, [[10, 10, 10], [20, 20, 20]])
+
     # Set to empty
     section.points = np.empty((0, 3))
     assert_array_equal(section.points, np.empty((0, 3)))


### PR DESCRIPTION
without having to re-copy the whole array every time.
Example, setting the points at index 2:

```
section.points[2] = [0.3, 1.2, -0.7]
```