### PR TITLE
Allow Origin keyword in ASC format

### DIFF
--- a/src/readers/lex.cpp
+++ b/src/readers/lex.cpp
@@ -41,6 +41,7 @@ enum class Token {
     LOW,
     NORMAL,
     MIDPOINT,
+    ORIGIN,
 };
 
 const std::map<Token, SectionType> TokenSectionTypeMap{{Token::AXON, SECTION_AXON},
@@ -83,6 +84,7 @@ inline std::string to_string(Token t) {
         T(LOW)
         T(NORMAL)
         T(MIDPOINT)
+        T(ORIGIN)
     default:
         return "Unknown";
 #undef T
@@ -162,6 +164,7 @@ class NeurolucidaLexer
         rules_.push("Low", +Token::LOW);
         rules_.push("Normal", +Token::NORMAL);
         rules_.push("Midpoint", +Token::MIDPOINT);
+        rules_.push("Origin", +Token::ORIGIN);
 
         rules_.push(R"(\"[^"]*\")", +Token::STRING);
 

--- a/src/readers/morphologyASC.cpp
+++ b/src/readers/morphologyASC.cpp
@@ -19,7 +19,8 @@ bool is_eof(Token type) {
 
 bool is_end_of_branch(Token type) {
     return (type == Token::GENERATED || type == Token::HIGH || type == Token::INCOMPLETE ||
-            type == Token::LOW || type == Token::NORMAL || type == Token::MIDPOINT);
+            type == Token::LOW || type == Token::NORMAL || type == Token::MIDPOINT ||
+            type == Token::ORIGIN);
 }
 
 bool is_neurite_type(Token id) {


### PR DESCRIPTION
As can be found in C050896A-P2.asc of the morphology repository