### PR TITLE
Implement Tristan's proposal Fix: #148

### DIFF
--- a/include/morphio/morphology.h
+++ b/include/morphio/morphology.h
@@ -12,6 +12,8 @@ enum SomaClasses { SOMA_CONTOUR, SOMA_CYLINDER };
 using breadth_iterator = breadth_iterator_t<Section, Morphology>;
 using depth_iterator = depth_iterator_t<Section, Morphology>;
 
+SomaType getSomaType(long unsigned int nSomaPoints) noexcept;
+
 /** Read access a Morphology file.
  *
  * Following RAII, this class is ready to use after the creation and will ensure

--- a/include/morphio/mut/soma.h
+++ b/include/morphio/mut/soma.h
@@ -7,8 +7,7 @@ namespace mut {
 class Soma
 {
   public:
-    Soma()
-        : _somaType(SOMA_UNDEFINED) {}
+    Soma() {}
 
     Soma(const Property::PointLevel& pointProperties);
     Soma(const Soma& soma);
@@ -31,7 +30,7 @@ class Soma
     /**
        Return the soma type
     **/
-    inline SomaType type() const noexcept;
+    SomaType type() const noexcept;
     /**
      * Return the center of gravity of the soma points
      **/
@@ -54,7 +53,6 @@ class Soma
 
   private:
     friend class Morphology;
-    SomaType _somaType;
     Property::PointLevel _pointProperties;
 };
 
@@ -74,9 +72,6 @@ const std::vector<float>& Soma::diameters() const noexcept {
     return _pointProperties._diameters;
 }
 
-inline SomaType Soma::type() const noexcept {
-    return _somaType;
-}
 
 inline Property::PointLevel& Soma::properties() noexcept {
     return _pointProperties;

--- a/include/morphio/soma.h
+++ b/include/morphio/soma.h
@@ -41,7 +41,7 @@ class Soma
     /**
      * Return the soma type
      **/
-    SomaType type() const noexcept;
+    inline SomaType type() const noexcept;
     /**
      * Return the center of gravity of the soma points
      **/
@@ -79,6 +79,10 @@ class Soma
 
 inline range<const Point> Soma::points() const noexcept {
     return _properties->_somaLevel._points;
+}
+
+inline SomaType Soma::type() const noexcept {
+    return _properties->_cellLevel._somaType;
 }
 
 inline range<const float> Soma::diameters() const noexcept {

--- a/include/morphio/soma.h
+++ b/include/morphio/soma.h
@@ -41,7 +41,7 @@ class Soma
     /**
      * Return the soma type
      **/
-    inline SomaType type() const noexcept;
+    SomaType type() const noexcept;
     /**
      * Return the center of gravity of the soma points
      **/
@@ -83,10 +83,6 @@ inline range<const Point> Soma::points() const noexcept {
 
 inline range<const float> Soma::diameters() const noexcept {
     return _properties->_somaLevel._diameters;
-}
-
-inline SomaType Soma::type() const noexcept {
-    return _properties->_cellLevel._somaType;
 }
 
 }  // namespace morphio

--- a/src/morphology.cpp
+++ b/src/morphology.cpp
@@ -19,7 +19,7 @@
 
 namespace morphio {
 void buildChildren(std::shared_ptr<Property::Properties> properties);
-SomaType getSomaType(long unsigned int nSomaPoints);
+
 
 Morphology::Morphology(const std::string& source, unsigned int options) {
     const size_t pos = source.find_last_of(".");
@@ -188,14 +188,18 @@ breadth_iterator Morphology::breadth_end() const {
     return breadth_iterator();
 }
 
-SomaType getSomaType(long unsigned int nSomaPoints) {
-    try {
-        return std::map<long unsigned int, SomaType>{{0, SOMA_UNDEFINED},
-                                                     {1, SOMA_SINGLE_POINT},
-                                                     {2, SOMA_UNDEFINED}}
-            .at(nSomaPoints);
-    } catch (const std::out_of_range&) {
+SomaType getSomaType(long unsigned int nSomaPoints) noexcept {
+    switch (nSomaPoints) {
+    case 0:
+    case 2: {
+        return SOMA_UNDEFINED;
+    }
+    case 1: {
+        return SOMA_SINGLE_POINT;
+    }
+    default: {
         return SOMA_SIMPLE_CONTOUR;
+    }
     }
 }
 

--- a/src/morphology.cpp
+++ b/src/morphology.cpp
@@ -1,6 +1,7 @@
 #include <cassert>
 #include <iostream>
 
+#include <array>
 #include <fstream>
 #include <streambuf>
 
@@ -188,19 +189,11 @@ breadth_iterator Morphology::breadth_end() const {
     return breadth_iterator();
 }
 
+std::array<SomaType, 3> nPoints2somaTypeMap = {SOMA_UNDEFINED, SOMA_SINGLE_POINT, SOMA_UNDEFINED};
 SomaType getSomaType(long unsigned int nSomaPoints) noexcept {
-    switch (nSomaPoints) {
-    case 0:
-    case 2: {
-        return SOMA_UNDEFINED;
-    }
-    case 1: {
-        return SOMA_SINGLE_POINT;
-    }
-    default: {
-        return SOMA_SIMPLE_CONTOUR;
-    }
-    }
+    // use of a std::array for speed
+    return (nSomaPoints < nPoints2somaTypeMap.size()) ? nPoints2somaTypeMap[nSomaPoints]
+                                                      : SOMA_SIMPLE_CONTOUR;
 }
 
 void buildChildren(std::shared_ptr<Property::Properties> properties) {

--- a/src/mut/soma.cpp
+++ b/src/mut/soma.cpp
@@ -9,16 +9,17 @@
 namespace morphio {
 namespace mut {
 Soma::Soma(const Property::PointLevel& pointProperties)
-    : _somaType(SOMA_UNDEFINED)
-    , _pointProperties(pointProperties) {}
+    : _pointProperties(pointProperties) {}
 
 Soma::Soma(const Soma& soma)
-    : _somaType(soma._somaType)
-    , _pointProperties(soma._pointProperties) {}
+    : _pointProperties(soma._pointProperties) {}
 
 Soma::Soma(const morphio::Soma& soma)
-    : _somaType(soma.type())
-    , _pointProperties(soma._properties->_somaLevel) {}
+    : _pointProperties(soma._properties->_somaLevel) {}
+
+SomaType Soma::type() const noexcept {
+    return morphio::getSomaType(points().size());
+}
 
 Point Soma::center() const {
     return centerOfGravity(points());

--- a/src/soma.cpp
+++ b/src/soma.cpp
@@ -9,6 +9,10 @@ namespace morphio {
 Soma::Soma(const std::shared_ptr<Property::Properties>& properties)
     : _properties(properties) {}
 
+SomaType Soma::type() const noexcept {
+    return morphio::getSomaType(points().size());
+}
+
 Point Soma::center() const {
     return centerOfGravity(_properties->_somaLevel._points);
 }

--- a/src/soma.cpp
+++ b/src/soma.cpp
@@ -9,10 +9,6 @@ namespace morphio {
 Soma::Soma(const std::shared_ptr<Property::Properties>& properties)
     : _properties(properties) {}
 
-SomaType Soma::type() const noexcept {
-    return morphio::getSomaType(points().size());
-}
-
 Point Soma::center() const {
     return centerOfGravity(_properties->_somaLevel._points);
 }


### PR DESCRIPTION
The soma type was stored in a variable in Soma that was readonly.
When the Neuron was created from scratch the type was set UNDEFINED
(since the neuron wa empty) and there was no way of changing it
afterwards. Now we rely entirely on the heuristic function
morphio::getSomaType() and removed the variable _somaType alltogether.

getSomaType() was also simplified as Tristan suggested: the map
creation&search has been substituted with a switch simplifiing the
code and adding the noexcept operator.

The change was implemented in mut::Soma as well as in Soma. Since
getSomaType() is O(1) it should not degrade performances.

- Remove somaType_ variable from Soma and mut::Soma.
- Simplify morphio::getSomaType adding noexcept for extra security.