### PR TITLE
cmake: install HighFive if we use the bundled version.

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -1,8 +1,10 @@
 find_package(HDF5 REQUIRED)
 
 if (NOT EXTERNAL_HIGHFIVE)
+  set(HIGHFIVE_EXAMPLES OFF CACHE BOOL "" FORCE)
+  set(HIGHFIVE_UNIT_TESTS OFF CACHE BOOL "" FORCE)
   set(HIGHFIVE_USE_BOOST OFF CACHE BOOL "" FORCE)
-  add_subdirectory(HighFive EXCLUDE_FROM_ALL)
+  add_subdirectory(HighFive)
   target_include_directories(HighFive SYSTEM INTERFACE)
 endif()
 

--- a/CMake/MorphIOConfig.cmake
+++ b/CMake/MorphIOConfig.cmake
@@ -1,5 +1,6 @@
 include(CMakeFindDependencyMacro)
 
 find_dependency(gsl-lite)
+find_dependency(HighFive)
 
 include("${CMAKE_CURRENT_LIST_DIR}/MorphIOTargets.cmake")


### PR DESCRIPTION
@wizmer this is required to have dependent libraries such as `morpho-kit` work *if* there is no external HighFive provided.