### PR TITLE
morphio::Morphology supports serialization through pickle

### DIFF
--- a/binds/python/bind_immutable.cpp
+++ b/binds/python/bind_immutable.cpp
@@ -146,7 +146,6 @@ void bind_immutable_module(py::module& m) {
             "- morphio.IterType.breadth_first (default)\n"
             "iter_type"_a = IterType::DEPTH_FIRST)
 
-        // Make class picklable
         .def(py::pickle(
             [](const morphio::Morphology& morphology) {  // __getstate__
                 // Return a tuple that fully encodes the state of the object

--- a/include/morphio/morphology.h
+++ b/include/morphio/morphology.h
@@ -37,6 +37,7 @@ class Morphology
         Example:
             Morphology("neuron.asc", TWO_POINTS_SECTIONS | SOMA_SPHERE);
      */
+    explicit Morphology(const std::stringstream& stream, unsigned int options = NO_MODIFIER);
     explicit Morphology(const std::string& source, unsigned int options = NO_MODIFIER);
     explicit Morphology(const HighFive::Group& group, unsigned int options = NO_MODIFIER);
     explicit Morphology(mut::Morphology);

--- a/include/morphio/mut/writers.h
+++ b/include/morphio/mut/writers.h
@@ -6,6 +6,8 @@ namespace writer {
 void swc(const Morphology& morphology, const std::string& filename);
 void asc(const Morphology& morphology, const std::string& filename);
 void h5(const Morphology& morphology, const std::string& filename);
+void _asc_to_stream(const Morphology& morphology, std::ostream& stream);
+bool _shouldBeWritten(const Morphology& morphology);
 }  // namespace writer
 }  // end namespace mut
 }  // end namespace morphio

--- a/src/morphology.cpp
+++ b/src/morphology.cpp
@@ -230,7 +230,7 @@ Property::Properties loadURI(const std::string& source, unsigned int options) {
             std::string input((std::istreambuf_iterator<char>(ifs)),
                               (std::istreambuf_iterator<char>()));
 
-            return readers::asc::load(input, source, options);
+            return readers::asc::load(std::move(input), source, options);
         }
         if (extension == ".swc" || extension == ".SWC")
             return readers::swc::load(source, options);

--- a/src/morphology.cpp
+++ b/src/morphology.cpp
@@ -47,6 +47,9 @@ Morphology::Morphology(const Property::Properties& properties, unsigned int opti
 Morphology::Morphology(const HighFive::Group& group, unsigned int options)
     : Morphology(readers::h5::load(group), options) {}
 
+Morphology::Morphology(const std::stringstream& stream, unsigned int options)
+    : Morphology(readers::asc::load(stream.str(), "Stream", options), options) {}
+
 Morphology::Morphology(const std::string& source, unsigned int options)
     : Morphology(loadURI(source, options), options) {}
 
@@ -222,8 +225,13 @@ Property::Properties loadURI(const std::string& source, unsigned int options) {
     auto loader = [&source, &options, &extension]() {
         if (extension == ".h5" || extension == ".H5")
             return readers::h5::load(source);
-        if (extension == ".asc" || extension == ".ASC")
-            return readers::asc::load(source, options);
+        if (extension == ".asc" || extension == ".ASC") {
+            std::ifstream ifs(source);
+            std::string input((std::istreambuf_iterator<char>(ifs)),
+                              (std::istreambuf_iterator<char>()));
+
+            return readers::asc::load(input, source, options);
+        }
         if (extension == ".swc" || extension == ".SWC")
             return readers::swc::load(source, options);
         throw(UnknownFileType("Unhandled file type: only SWC, ASC and H5 are supported"));

--- a/src/readers/morphologyASC.cpp
+++ b/src/readers/morphologyASC.cpp
@@ -42,9 +42,10 @@ bool skip_sexp(size_t id) {
 class NeurolucidaParser
 {
   public:
-    explicit NeurolucidaParser(const std::string& uri)
+    explicit NeurolucidaParser(const std::string& input, const std::string& uri)
         : uri_(uri)
         , lex_(uri)
+        , input_(input)
         , debugInfo_(uri)
         , err_(uri) {}
 
@@ -52,11 +53,7 @@ class NeurolucidaParser
     NeurolucidaParser& operator=(NeurolucidaParser const&) = delete;
 
     morphio::mut::Morphology& parse() {
-        std::ifstream ifs(uri_);
-        std::string input((std::istreambuf_iterator<char>(ifs)),
-                          (std::istreambuf_iterator<char>()));
-
-        lex_.start_parse(input);
+        lex_.start_parse(input_);
 
         parse_block();
 
@@ -249,6 +246,7 @@ class NeurolucidaParser
 
     std::string uri_;
     NeurolucidaLexer lex_;
+    std::string input_;
 
   public:
     DebugInfo debugInfo_;
@@ -257,8 +255,8 @@ class NeurolucidaParser
     ErrorMessages err_;
 };
 
-Property::Properties load(const std::string& uri, unsigned int options) {
-    NeurolucidaParser parser(uri);
+Property::Properties load(const std::string& input, const std::string& uri, unsigned int options) {
+    NeurolucidaParser parser(input, uri);
 
     morphio::mut::Morphology& nb_ = parser.parse();
     nb_.sanitize(parser.debugInfo_);

--- a/src/readers/morphologyASC.cpp
+++ b/src/readers/morphologyASC.cpp
@@ -42,10 +42,10 @@ bool skip_sexp(size_t id) {
 class NeurolucidaParser
 {
   public:
-    explicit NeurolucidaParser(const std::string& input, const std::string& uri)
+    explicit NeurolucidaParser(const std::string&& input, const std::string& uri)
         : uri_(uri)
         , lex_(uri)
-        , input_(std::move(input))
+        , input_(input)
         , debugInfo_(uri)
         , err_(uri) {}
 
@@ -255,8 +255,8 @@ class NeurolucidaParser
     ErrorMessages err_;
 };
 
-Property::Properties load(const std::string& input, const std::string& uri, unsigned int options) {
-    NeurolucidaParser parser(input, uri);
+Property::Properties load(const std::string&& input, const std::string& uri, unsigned int options) {
+    NeurolucidaParser parser(std::move(input), uri);
 
     morphio::mut::Morphology& nb_ = parser.parse();
     nb_.sanitize(parser.debugInfo_);

--- a/src/readers/morphologyASC.cpp
+++ b/src/readers/morphologyASC.cpp
@@ -45,7 +45,7 @@ class NeurolucidaParser
     explicit NeurolucidaParser(const std::string& input, const std::string& uri)
         : uri_(uri)
         , lex_(uri)
-        , input_(input)
+        , input_(std::move(input))
         , debugInfo_(uri)
         , err_(uri) {}
 

--- a/src/readers/morphologyASC.cpp
+++ b/src/readers/morphologyASC.cpp
@@ -42,7 +42,7 @@ bool skip_sexp(size_t id) {
 class NeurolucidaParser
 {
   public:
-    explicit NeurolucidaParser(const std::string&& input, const std::string& uri)
+    explicit NeurolucidaParser(std::string&& input, const std::string& uri)
         : uri_(uri)
         , lex_(uri)
         , input_(input)
@@ -255,7 +255,7 @@ class NeurolucidaParser
     ErrorMessages err_;
 };
 
-Property::Properties load(const std::string&& input, const std::string& uri, unsigned int options) {
+Property::Properties load(std::string&& input, const std::string& uri, unsigned int options) {
     NeurolucidaParser parser(std::move(input), uri);
 
     morphio::mut::Morphology& nb_ = parser.parse();

--- a/src/readers/morphologyASC.h
+++ b/src/readers/morphologyASC.h
@@ -4,7 +4,7 @@
 namespace morphio {
 namespace readers {
 namespace asc {
-Property::Properties load(const std::string& input, const std::string& uri, unsigned int options);
+Property::Properties load(const std::string&& input, const std::string& uri, unsigned int options);
 }  // namespace asc
 }  // namespace readers
 }  // namespace morphio

--- a/src/readers/morphologyASC.h
+++ b/src/readers/morphologyASC.h
@@ -4,7 +4,7 @@
 namespace morphio {
 namespace readers {
 namespace asc {
-Property::Properties load(const std::string&& input, const std::string& uri, unsigned int options);
+Property::Properties load(std::string&& input, const std::string& uri, unsigned int options);
 }  // namespace asc
 }  // namespace readers
 }  // namespace morphio

--- a/src/readers/morphologyASC.h
+++ b/src/readers/morphologyASC.h
@@ -4,7 +4,7 @@
 namespace morphio {
 namespace readers {
 namespace asc {
-Property::Properties load(const std::string& uri, unsigned int options);
+Property::Properties load(const std::string& input, const std::string& uri, unsigned int options);
 }  // namespace asc
 }  // namespace readers
 }  // namespace morphio


### PR DESCRIPTION
https://pybind11.readthedocs.io/en/stable/advanced/classes.html#pickling-support

This is a simplistic attempt at supporting Pickle.
The serialization simply returns a string with the NeuroLucida representation of
the morphology.

A new morphio::Morphology ctor that takes a stringstream argument has been
added. It is used for the deserialization.