### PR TITLE
highfive: bump, remove bogus constructor.

### DIFF
--- a/src/readers/morphologyHDF5.cpp
+++ b/src/readers/morphologyHDF5.cpp
@@ -61,10 +61,6 @@ namespace morphio {
 namespace readers {
 namespace h5 {
 
-MorphologyHDF5::MorphologyHDF5(const HighFive::Group& group)
-    : _group(group)
-    , _uri("HDF5 Group") {}
-
 Property::Properties load(const std::string& uri) {
     try {
         HighFive::SilenceHDF5 silence;
@@ -94,6 +90,10 @@ Property::Properties MorphologyHDF5::load() {
 
     return _properties;
 }
+
+MorphologyHDF5::MorphologyHDF5(const HighFive::Group& group)
+    : _group(group)
+    , _uri("HDF5 Group") {}
 
 void MorphologyHDF5::_checkVersion(const std::string& source) {
     if (_readV11Metadata())

--- a/src/readers/morphologyHDF5.h
+++ b/src/readers/morphologyHDF5.h
@@ -19,9 +19,6 @@ Property::Properties load(const HighFive::Group& group);
 class MorphologyHDF5
 {
   public:
-    MorphologyHDF5(const std::string& uri)
-        : _err(uri)
-        , _uri(uri) {}
     MorphologyHDF5(const HighFive::Group& group);
     virtual ~MorphologyHDF5() = default;
     Property::Properties load();


### PR DESCRIPTION
Recent HighFive API changes block compilation with an external HighFive.
Update the HighFive submodule and remove legacy constructors in the HDF5
reader that broke with the API update.