### PR TITLE
Handling missing duplicate points

### DIFF
--- a/src/readers/morphologyASC.cpp
+++ b/src/readers/morphologyASC.cpp
@@ -150,6 +150,7 @@ class NeurolucidaParser
     /*
       Add the last point of parent section to the beginning of this section
       if not already present.
+      See https://github.com/BlueBrain/MorphIO/pull/221
 
       The diameter is taken from the child section next point as does NEURON.
       Here is the spec:
@@ -158,19 +159,19 @@ class NeurolucidaParser
       In term of diameters, the result should look like the right picture of:
       https://github.com/BlueBrain/NeuroM/issues/654#issuecomment-332864540
 
-      The idea is that these two structures should represent the same morphology:
+     The idea is that these two structures should represent the same morphology:
 
-      (3 -8 0 2)     and          (3 -8 0 2)
-      (3 -10 0 2)                 (3 -10 0 2)
-      (                           (
-        (0 -10 0 2)                 (3 -10 0 2)  <-- duplicate parent point
-        (-3 -10 0 2)                (0 -10 0 2)
-        |                           (-3 -10 0 2)
-        (6 -10 0 2)                 |
-        (9 -10 0 2)                 (3 -10 0 2)  <-- duplicate parent point
-      )                             (6 -10 0 2)
-                                    (9 -10 0 2)
-                                  )
+     (3 -8 0 5)     and          (3 -8 0 5)
+     (3 -10 0 5)                 (3 -10 0 5)
+     (                           (
+       (0 -10 0 2)                 (3 -10 0 2)  <-- duplicate parent point, note that the
+       (-3 -10 0 2)                (0 -10 0 2)      diameter is 2 and not 5
+       |                           (-3 -10 0 2)
+       (6 -10 0 2)                 |
+       (9 -10 0 2)                 (3 -10 0 2)  <-- duplicate parent point, note that the
+     )                             (6 -10 0 2)      diameter is 2 and not 5
+                                   (9 -10 0 2)
+                                 )
      */
     void insertLastPointParentSection(int32_t parentId,
                                       morphio::Property::PointLevel& properties,

--- a/tests/data/nested_single_children.asc
+++ b/tests/data/nested_single_children.asc
@@ -5,14 +5,15 @@
 
 ( (Color Blue)
   (Axon)
-  (0 0 0 1)
-  (0 0 1 1)
+  (0 0 0 8)
+  (0 0 1 7)
   (
-    (0 0 2 1)
+    (0 0 2 6)
     (
-      (0 0 3 1)
+      (0 0 2 6) ; this duplicate should disapear in the merge
+      (0 0 3 5)
       (
-        (0 0 4 1)
+        (0 0 4 4)
       )
     )
   )


### PR DESCRIPTION
## What is a duplicate point ?

When a child section starts with a point at the same coordinates as the parent
section last point, we call this a 'duplicate point'.

ℹ️  To consider a point as a duplicate, we only consider its spatial coordinates.
The diameter is not taken into account. This means a duplicate is allowed to
have any diameter value.

## Context:

Some ASC files comes with duplicate points, some do not. So it seems that both
representations are valid and need to be supported.

## Specification

The following specification has been created to exactly recreate NEURON's behavior:

* When a duplicate point is **not** in the file (ie. a section does not start at the
coordinate of its parent section last point), the duplicate is added. The
diameter of the added point is the diameter of the point that comes right after
it.

* When a duplicate is already in the file, its coordinates and diameter value
are used as they are.

* When a single child section is merged with its parent section and the child
section has a duplicate with a different diameter value, the diameter of the
**parent** section is kept.

## More information

* https://bbpteam.epfl.ch/project/issues/browse/NSETM-1178?focusedCommentId=135030&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-135030
* https://github.com/BlueBrain/NeuroM/issues/654#issuecomment-332864540