### PR TITLE
Add support for BBP generated markers

### DIFF
--- a/src/readers/lex.cpp
+++ b/src/readers/lex.cpp
@@ -172,6 +172,7 @@ class NeurolucidaLexer
         rules_.push("OpenSquare", +Token::MARKER);
         rules_.push("FilledStar", +Token::MARKER);
         rules_.push("DoubleCircle", +Token::MARKER);
+        rules_.push("Circle[0-9]+", +Token::MARKER);
 
         rules_.push("Generated", +Token::GENERATED);
         rules_.push("High", +Token::HIGH);

--- a/tests/test_2_neurolucida.py
+++ b/tests/test_2_neurolucida.py
@@ -13,7 +13,7 @@ from .utils import _test_asc_exception, assert_substring, captured_output, tmp_a
 DATA_DIR = Path(__file__).parent / 'data'
 
 NEUROLUCIDA_MARKERS = ['Dot', 'FilledCircle', 'SnowFlake', 'Asterisk', 'OpenCircle',
-                       'OpenStar', 'Flower', 'OpenSquare', 'FilledStar', 'DoubleCircle']
+                       'OpenStar', 'Flower', 'OpenSquare', 'FilledStar', 'DoubleCircle', 'Circle1']
 
 
 def test_soma():


### PR DESCRIPTION
At BBP we annotate files with potential issues with the Circle markers.
https://github.com/BlueBrain/MorphIO/issues/226

This commit adds support for such markers.