### PR TITLE
Refactor versioning

### DIFF
--- a/.github/workflows/publish-sdist-wheels.yml
+++ b/.github/workflows/publish-sdist-wheels.yml
@@ -1,9 +1,10 @@
 name: Publish sdist and wheels macos-manylinux
 
 on:
-  push:
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+  pull_request:
+  # push:
+  #   tags:
+  #     - 'v[0-9]+.[0-9]+.[0-9]+'
 
 env:
   CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
@@ -58,42 +59,42 @@ jobs:
           name: dist
           path: dist
 
-  build_sdist:
-    name: Build sdist
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@master
-      - name: Set up Python 3.6
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.6
-      - name: Build a source tarball
-        run:
-          python setup.py sdist
-      - name: Store sdist as artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: dist
-          path: dist
+  # build_sdist:
+  #   name: Build sdist
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@master
+  #     - name: Set up Python 3.6
+  #       uses: actions/setup-python@v2
+  #       with:
+  #         python-version: 3.6
+  #     - name: Build a source tarball
+  #       run:
+  #         python setup.py sdist
+  #     - name: Store sdist as artifact
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: dist
+  #         path: dist
 
-  upload_wheels:
-    runs-on: ubuntu-latest
-    needs: [build_wheels, build_sdist]
-    name: Upload wheels to PyPI
-    steps:
-      - name: Download artifacts produced during the build_wheels and build_sdist jobs
-        uses: actions/download-artifact@v2
-        with:
-          name: dist
-          path: dist
+  # upload_wheels:
+  #   runs-on: ubuntu-latest
+  #   needs: [build_wheels, build_sdist]
+  #   name: Upload wheels to PyPI
+  #   steps:
+  #     - name: Download artifacts produced during the build_wheels and build_sdist jobs
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         name: dist
+  #         path: dist
 
-      - name: Display structure of downloaded files
-        run: ls -R
-        working-directory: dist
+  #     - name: Display structure of downloaded files
+  #       run: ls -R
+  #       working-directory: dist
 
-      - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_PASSWORD }}
-          packages_dir: dist/
+  #     - name: Publish package to PyPI
+  #       uses: pypa/gh-action-pypi-publish@master
+  #       with:
+  #         user: __token__
+  #         password: ${{ secrets.PYPI_PASSWORD }}
+  #         packages_dir: dist/

--- a/.github/workflows/publish-sdist-wheels.yml
+++ b/.github/workflows/publish-sdist-wheels.yml
@@ -1,10 +1,9 @@
 name: Publish sdist and wheels macos-manylinux
 
 on:
-  pull_request:
-  # push:
-  #   tags:
-  #     - 'v[0-9]+.[0-9]+.[0-9]+'
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 env:
   CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
@@ -59,42 +58,42 @@ jobs:
           name: dist
           path: dist
 
-  # build_sdist:
-  #   name: Build sdist
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@master
-  #     - name: Set up Python 3.6
-  #       uses: actions/setup-python@v2
-  #       with:
-  #         python-version: 3.6
-  #     - name: Build a source tarball
-  #       run:
-  #         python setup.py sdist
-  #     - name: Store sdist as artifact
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: dist
-  #         path: dist
+  build_sdist:
+    name: Build sdist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Python 3.6
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+      - name: Build a source tarball
+        run:
+          python setup.py sdist
+      - name: Store sdist as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: dist
 
-  # upload_wheels:
-  #   runs-on: ubuntu-latest
-  #   needs: [build_wheels, build_sdist]
-  #   name: Upload wheels to PyPI
-  #   steps:
-  #     - name: Download artifacts produced during the build_wheels and build_sdist jobs
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         name: dist
-  #         path: dist
+  upload_wheels:
+    runs-on: ubuntu-latest
+    needs: [build_wheels, build_sdist]
+    name: Upload wheels to PyPI
+    steps:
+      - name: Download artifacts produced during the build_wheels and build_sdist jobs
+        uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: dist
 
-  #     - name: Display structure of downloaded files
-  #       run: ls -R
-  #       working-directory: dist
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: dist
 
-  #     - name: Publish package to PyPI
-  #       uses: pypa/gh-action-pypi-publish@master
-  #       with:
-  #         user: __token__
-  #         password: ${{ secrets.PYPI_PASSWORD }}
-  #         packages_dir: dist/
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_PASSWORD }}
+          packages_dir: dist/

--- a/binds/python/bind_misc.cpp
+++ b/binds/python/bind_misc.cpp
@@ -80,23 +80,6 @@ void bind_misc(py::module& m) {
         .export_values();
 
 
-    py::enum_<morphio::enums::MorphologyVersion>(m, "MorphologyVersion")
-        .value("MORPHOLOGY_VERSION_H5_1",
-               morphio::enums::MorphologyVersion::MORPHOLOGY_VERSION_H5_1)
-        .value("MORPHOLOGY_VERSION_H5_2",
-               morphio::enums::MorphologyVersion::MORPHOLOGY_VERSION_H5_2)
-        .value("MORPHOLOGY_VERSION_H5_1_1",
-               morphio::enums::MorphologyVersion::MORPHOLOGY_VERSION_H5_1_1)
-        .value("MORPHOLOGY_VERSION_H5_1_2",
-               morphio::enums::MorphologyVersion::MORPHOLOGY_VERSION_H5_1_2)
-        .value("MORPHOLOGY_VERSION_SWC_1",
-               morphio::enums::MorphologyVersion::MORPHOLOGY_VERSION_SWC_1)
-        .value("MORPHOLOGY_VERSION_UNDEFINED",
-               morphio::enums::MorphologyVersion::MORPHOLOGY_VERSION_UNDEFINED)
-        .value("MORPHOLOGY_VERSION_ASC_1",
-               morphio::enums::MorphologyVersion::MORPHOLOGY_VERSION_ASC_1)
-        .export_values();
-
     py::enum_<morphio::enums::CellFamily>(m, "CellFamily")
         .value("NEURON", morphio::enums::CellFamily::NEURON)
         .value("GLIA", morphio::enums::CellFamily::GLIA)

--- a/include/morphio/enums.h
+++ b/include/morphio/enums.h
@@ -35,19 +35,6 @@ enum Warning {
     WRITE_EMPTY_MORPHOLOGY
 };
 
-/** The supported versions for morphology files. */
-enum MorphologyVersion {
-    MORPHOLOGY_VERSION_H5_1 = 1,
-    MORPHOLOGY_VERSION_H5_2 = 2,
-    MORPHOLOGY_VERSION_H5_1_1 = 3,
-    MORPHOLOGY_VERSION_ASC_1 = 4,
-    MORPHOLOGY_VERSION_SWC_1 = 101,
-    MORPHOLOGY_VERSION_H5_1_2 = 5,
-    MORPHOLOGY_VERSION_UNDEFINED
-};
-std::ostream& operator<<(std::ostream& os, MorphologyVersion v);
-
-
 enum AnnotationType {
     SINGLE_CHILD,
 };

--- a/include/morphio/properties.h
+++ b/include/morphio/properties.h
@@ -151,8 +151,9 @@ struct Marker {
 };
 
 struct CellLevel {
-    CellLevel()
-          _version({"undefined", 0, 0}) {}
+    CellLevel() : _version({"undefined", 0, 0}) {}
+
+    // A tuple (file format (std::string), major version, minor version)
     MorphologyVersion _version;
     morphio::CellFamily _cellFamily;
     SomaType _somaType;

--- a/include/morphio/properties.h
+++ b/include/morphio/properties.h
@@ -151,7 +151,8 @@ struct Marker {
 };
 
 struct CellLevel {
-    CellLevel() : _version({"undefined", 0, 0}) {}
+    CellLevel()
+        : _version({"undefined", 0, 0}) {}
 
     // A tuple (file format (std::string), major version, minor version)
     MorphologyVersion _version;

--- a/include/morphio/properties.h
+++ b/include/morphio/properties.h
@@ -192,7 +192,7 @@ struct Properties {
     template <typename T>
     const std::vector<typename T::Type>& get() const noexcept;
 
-    const MorphologyVersion& version() const noexcept {
+    const morphio::MorphologyVersion& version() const noexcept {
         return _cellLevel._version;
     }
     const morphio::CellFamily& cellFamily() const noexcept {

--- a/include/morphio/properties.h
+++ b/include/morphio/properties.h
@@ -152,7 +152,7 @@ struct Marker {
 
 struct CellLevel {
     CellLevel()
-        : _version(MORPHOLOGY_VERSION_UNDEFINED) {}
+          _version({"undefined", 0, 0}) {}
     MorphologyVersion _version;
     morphio::CellFamily _cellFamily;
     SomaType _somaType;
@@ -162,6 +162,9 @@ struct CellLevel {
     bool diff(const CellLevel& other, LogLevel logLevel) const;
     bool operator==(const CellLevel& other) const;
     bool operator!=(const CellLevel& other) const;
+    std::string fileFormat() const;
+    uint32_t majorVersion();
+    uint32_t minorVersion();
 };
 
 // The lowest level data blob
@@ -188,10 +191,7 @@ struct Properties {
     template <typename T>
     const std::vector<typename T::Type>& get() const noexcept;
 
-    morphio::MorphologyVersion& version() noexcept {
-        return _cellLevel._version;
-    }
-    const morphio::MorphologyVersion& version() const noexcept {
+    const MorphologyVersion& version() const noexcept {
         return _cellLevel._version;
     }
     const morphio::CellFamily& cellFamily() const noexcept {

--- a/include/morphio/types.h
+++ b/include/morphio/types.h
@@ -47,6 +47,7 @@ class Soma;
 }  // namespace mut
 
 using SectionRange = std::pair<size_t, size_t>;
+using MorphologyVersion = std::tuple<std::string, uint32_t, uint32_t>;
 
 template <typename T>
 using range = gsl::span<T>;

--- a/morphio/__init__.py
+++ b/morphio/__init__.py
@@ -15,7 +15,6 @@ from ._morphio import (
     MitochondriaPointLevel,
     MorphioError,
     Morphology,
-    MorphologyVersion,
     MultipleTrees,
     Option,
     PointLevel,

--- a/src/enums.cpp
+++ b/src/enums.cpp
@@ -5,27 +5,6 @@ namespace morphio {
 namespace enums {
 
 /** Output stream formatter for MorphologyVersion */
-std::ostream& operator<<(std::ostream& os, const MorphologyVersion v) {
-    switch (v) {
-    case MORPHOLOGY_VERSION_H5_1:
-        return os << "h5v1";
-    case MORPHOLOGY_VERSION_H5_1_1:
-        return os << "h5v1.1";
-    case MORPHOLOGY_VERSION_H5_1_2:
-        return os << "h5v1.2";
-    case MORPHOLOGY_VERSION_H5_2:
-        return os << "h5v2";
-    case MORPHOLOGY_VERSION_SWC_1:
-        return os << "swcv1";
-    case MORPHOLOGY_VERSION_ASC_1:
-        return os << "ascv1";
-    default:
-    case MORPHOLOGY_VERSION_UNDEFINED:
-        return os << "UNDEFINED";
-    }
-}
-
-/** Output stream formatter for MorphologyVersion */
 std::ostream& operator<<(std::ostream& os, const SomaType v) {
     switch (v) {
     case SOMA_SINGLE_POINT:

--- a/src/morphology.cpp
+++ b/src/morphology.cpp
@@ -27,13 +27,12 @@ Morphology::Morphology(const Property::Properties& properties, unsigned int opti
     : _properties(std::make_shared<Property::Properties>(properties)) {
     buildChildren(_properties);
 
-    if (version() != MORPHOLOGY_VERSION_SWC_1)
+    if (fileFormat() != "swc")
         _properties->_cellLevel._somaType = getSomaType(soma().points().size());
 
     // For SWC and ASC, sanitization and modifier application are already taken care of by
     // their respective loaders
-    if ((version() == MORPHOLOGY_VERSION_H5_1 || version() == MORPHOLOGY_VERSION_H5_1_1 ||
-         version() == MORPHOLOGY_VERSION_H5_2)) {
+    if (fileFormat() == "h5") {
         mut::Morphology mutable_morph(*this);
         mutable_morph.sanitize();
         if (options) {

--- a/src/morphology.cpp
+++ b/src/morphology.cpp
@@ -27,12 +27,12 @@ Morphology::Morphology(const Property::Properties& properties, unsigned int opti
     : _properties(std::make_shared<Property::Properties>(properties)) {
     buildChildren(_properties);
 
-    if (fileFormat() != "swc")
+    if (_properties->_cellLevel.fileFormat() != "swc")
         _properties->_cellLevel._somaType = getSomaType(soma().points().size());
 
     // For SWC and ASC, sanitization and modifier application are already taken care of by
     // their respective loaders
-    if (fileFormat() == "h5") {
+    if (properties._cellLevel.fileFormat() == "h5") {
         mut::Morphology mutable_morph(*this);
         mutable_morph.sanitize();
         if (options) {

--- a/src/mut/writers.cpp
+++ b/src/mut/writers.cpp
@@ -374,7 +374,7 @@ void h5(const Morphology& morpho, const std::string& filename) {
 
     HighFive::Group g_metadata = h5_file.createGroup("metadata");
 
-    write_attribute(g_metadata, "version", std::vector<uint32_t>{1, 1});
+    write_attribute(g_metadata, "version", std::vector<uint32_t>{1, 2});
     write_attribute(g_metadata, "cell_family", std::vector<uint32_t>{morpho.cellFamily()});
     write_attribute(h5_file, "comment", std::vector<std::string>{version_string()});
 

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -217,6 +217,16 @@ bool CellLevel::operator!=(const CellLevel& other) const {
     return diff(other, LogLevel::ERROR);
 }
 
+std::string CellLevel::fileFormat() const {
+    return std::get<0>(_version);
+}
+    uint32_t CellLevel::majorVersion() {
+        return std::get<1>(_version);
+    }
+    std::string CellLevel::minorVersion() {
+        return std::get<2>(_version);
+    }
+
 
 MitochondriaPointLevel::MitochondriaPointLevel(const MitochondriaPointLevel& data,
                                                const SectionRange& range) {

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -223,7 +223,7 @@ std::string CellLevel::fileFormat() const {
     uint32_t CellLevel::majorVersion() {
         return std::get<1>(_version);
     }
-    std::string CellLevel::minorVersion() {
+    uint32_t CellLevel::minorVersion() {
         return std::get<2>(_version);
     }
 

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -220,12 +220,14 @@ bool CellLevel::operator!=(const CellLevel& other) const {
 std::string CellLevel::fileFormat() const {
     return std::get<0>(_version);
 }
-    uint32_t CellLevel::majorVersion() {
-        return std::get<1>(_version);
-    }
-    uint32_t CellLevel::minorVersion() {
-        return std::get<2>(_version);
-    }
+
+uint32_t CellLevel::majorVersion() {
+    return std::get<1>(_version);
+}
+
+uint32_t CellLevel::minorVersion() {
+    return std::get<2>(_version);
+}
 
 
 MitochondriaPointLevel::MitochondriaPointLevel(const MitochondriaPointLevel& data,

--- a/src/readers/morphologyASC.cpp
+++ b/src/readers/morphologyASC.cpp
@@ -353,7 +353,7 @@ Property::Properties load(const std::string& uri, unsigned int options) {
 
     Property::Properties properties = nb_.buildReadOnly();
     properties._cellLevel._cellFamily = NEURON;
-    properties._cellLevel._version[0] = "asc";
+    properties._cellLevel._version = {"asc", 1, 0};
     return properties;
 }
 

--- a/src/readers/morphologyASC.cpp
+++ b/src/readers/morphologyASC.cpp
@@ -353,7 +353,7 @@ Property::Properties load(const std::string& uri, unsigned int options) {
 
     Property::Properties properties = nb_.buildReadOnly();
     properties._cellLevel._cellFamily = NEURON;
-    properties._cellLevel._version = MORPHOLOGY_VERSION_ASC_1;
+    properties._cellLevel._version[0] = "asc";
     return properties;
 }
 

--- a/src/readers/morphologyHDF5.cpp
+++ b/src/readers/morphologyHDF5.cpp
@@ -278,8 +278,8 @@ int MorphologyHDF5::_readSections() {
 
 void MorphologyHDF5::_readPerimeters(int firstSectionOffset) {
     // Perimeter information is available starting at v1.1
-    if (!(_properties._cellLevel.majorVersion() == 1 &&
-          _properties._cellLevel.minorVersion() > 0 && HasNeurites(firstSectionOffset)))
+    if (!(_properties._cellLevel.majorVersion() == 1 && _properties._cellLevel.minorVersion() > 0 &&
+          HasNeurites(firstSectionOffset)))
         return;
 
     try {
@@ -308,8 +308,7 @@ void MorphologyHDF5::_read(const std::string& groupName,
                            const std::string& _dataset,
                            unsigned int expectedDimension,
                            T& data) {
-    if (_properties._cellLevel.majorVersion() != 1 ||
-        _properties._cellLevel.minorVersion() < 1)
+    if (_properties._cellLevel.majorVersion() != 1 || _properties._cellLevel.minorVersion() < 1)
         return;
     try {
         const auto group = _group.getGroup(groupName);

--- a/src/readers/morphologyHDF5.h
+++ b/src/readers/morphologyHDF5.h
@@ -37,7 +37,6 @@ class MorphologyHDF5
     template <typename T>
     void _read(const std::string& group,
                const std::string& _dataset,
-               MorphologyVersion version,
                unsigned int expectedDimension,
                T& data);
 

--- a/src/readers/morphologySWC.cpp
+++ b/src/readers/morphologySWC.cpp
@@ -353,7 +353,7 @@ class SWCBuilder
 Property::Properties load(const std::string& uri, unsigned int options) {
     auto properties = SWCBuilder(uri)._buildProperties(options);
     properties._cellLevel._cellFamily = NEURON;
-    properties._cellLevel._version = MORPHOLOGY_VERSION_SWC_1;
+    properties._cellLevel._version = {"swc", 1, 0};
     return properties;
 }
 

--- a/tests/test_1_swc.py
+++ b/tests/test_1_swc.py
@@ -447,3 +447,7 @@ def test_root_node_split():
 def test_three_point_soma():
     n = Morphology(os.path.join(_path, 'three_point_soma.swc'))
     assert_equal(n.soma_type, SomaType.SOMA_NEUROMORPHO_THREE_POINT_CYLINDERS)
+
+def test_version():
+    assert_array_equal(Morphology(os.path.join(_path, 'simple.swc')).version,
+                       ('swc', 1, 0))

--- a/tests/test_2_neurolucida.py
+++ b/tests/test_2_neurolucida.py
@@ -705,3 +705,5 @@ def test_marker_with_string():
     m = Morphology(DATA_DIR / 'marker-with-string.asc')
     assert_array_equal(m.markers[0].points, np.array([[  -0.97    , -141.169998,   84.769997]],
                                                      dtype=np.float32))
+def test_version():
+    assert_array_equal(Morphology(DATA_DIR / 'simple.asc').version, ('asc', 1, 0))

--- a/tests/test_3_h5.py
+++ b/tests/test_3_h5.py
@@ -3,7 +3,7 @@ from itertools import chain, repeat
 from pathlib import Path
 
 import requests
-from morphio import (CellFamily, Morphology, MorphologyVersion, RawDataError, SectionType,
+from morphio import (CellFamily, Morphology, RawDataError, SectionType,
                      ostream_redirect)
 from nose.tools import assert_equal, assert_raises, ok_
 from numpy.testing import assert_array_equal
@@ -21,10 +21,10 @@ def test_v1():
     assert_equal(len(n.root_sections), 2)
     assert_equal(n.root_sections[0].type, 3)
     assert_equal(n.root_sections[1].type, 2)
-    assert_equal(n.version, MorphologyVersion.MORPHOLOGY_VERSION_H5_1_1)
+    assert_equal(n.version, ("h5", 1, 1))
 
     n = Morphology(H5V1_PATH / 'Neuron.h5')
-    assert_equal(n.version, MorphologyVersion.MORPHOLOGY_VERSION_H5_1)
+    assert_equal(n.version, ("h5", 1, 0))
 
     assert_equal(len(n.sections), 84)
     assert_equal(len(n.soma.points), 3)


### PR DESCRIPTION
No longer use an enum as the return type of `Morphology::version()` but a tuple <string, int, int>. The three fields are:

- file format extension. One of "h5", "asc", "swc"
- major version for the given format
- minor version for the given format

So far the existing values are:
- ("swc", 1, 0)
- ("asc", 1, 0)
- ("h5", 1, 0)
- ("h5", 1, 1)
- ("h5", 1, 2)

The advantage is that versions can now be ordered within a given file format.

* Fix the metadata version field in H5. It is now 1.2 instead of 1.1 as per the spec:  https://bbpteam.epfl.ch/documentation/projects/Morphology%20Documentation/latest/h5v1.html