### PR TITLE
Allow markers to have no diameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,6 +573,8 @@ The following s-expressions are parsed:
   )  ;  End of markers
   ```
 
+ℹ️ Markers can may have only `(X Y Z)` specified instead of the more common `(X Y Z D)`. In this case, diameters are set to 0.
+
 ##### Usage
 
 ```python

--- a/tests/data/marker-with-string.asc
+++ b/tests/data/marker-with-string.asc
@@ -1,0 +1,12 @@
+; The following annotation has been found in C280999A-I4.asc
+; It is a top-level annotation with a quote inside
+( (Color Red)
+  (   -0.97  -141.17    84.77)
+  "<--4 boutons on a PC soma"
+)  ;  End of text
+
+("CellBody"
+ (Color Red)
+ (CellBody)
+ (0 0 0 2)
+ )

--- a/tests/test_2_neurolucida.py
+++ b/tests/test_2_neurolucida.py
@@ -700,3 +700,8 @@ def test_skip_imagecoord():
 def test_Sections_block():
     assert_array_equal(Morphology(DATA_DIR / 'sections-block.asc').points,
                        Morphology(DATA_DIR / 'simple.asc').points)
+
+def test_marker_with_string():
+    m = Morphology(DATA_DIR / 'marker-with-string.asc')
+    assert_array_equal(m.markers[0].points, np.array([[  -0.97    , -141.169998,   84.769997]],
+                                                     dtype=np.float32))


### PR DESCRIPTION
Markers may have only `(X Y Z)` specified instead of the more common `(X Y Z D)`. In this case, diameters are set to 0.

Also:
Strings in the middle of the list of points are now skipped.

ℹ️ The example file added in this commit is based on C280999A-I4.asc
It illustrates both use cases.