### PR TITLE
Fix lifetime issue of mutable morphs #161

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ It supports the following formats:
 - SWC
 - ASC (aka. neurolucida)
 - H5 v1
-- H5 v2
 
 It provides 3 C++ classes that are the starting point of every morphology analysis:
 - `Soma`: contains the information related to the soma.
@@ -173,15 +172,18 @@ from morphio.mut import Morphology, Section, Soma
 
 #### C++
 
+⚠️`morphio::mut::Morphology` object **have** to be created through a shared pointer and not directly on the stack. Failure to do so will result in errors while trying to initialize the sections.
+
 ```cpp
-#include <morphio/morphology.h>
-#include <morphio/section.h>
+#include <morphio/mut/morphology.h>
+#include <morphio/mut/section.h>
 
 int main()
 {
-    auto m = morphio::Morphology("sample.asc");
+    auto m = std::make_shared<morphio::mut::Morphology>();
+    m->init("sample.asc");
 
-    auto roots = m.rootSections();
+    auto roots = m->rootSections();
 
     auto first_root = roots[0];
 
@@ -207,7 +209,7 @@ int main()
 #### Python
 
 ```python
-from morphio import Morphology
+from morphio.mut import Morphology
 
 m = Morphology("sample.asc")
 roots = m.root_sections
@@ -235,7 +237,7 @@ Here is a simple example to create a morphology from scratch and write it to dis
 
 int main()
 {
-    morphio::mut::Morphology morpho;
+    auto morpho = std::make_shared<morphio::mut::Morphology>();
     morpho.soma()->points() = {{0, 0, 0}, {1, 1, 1}};
     morpho.soma()->diameters() = {1, 1};
 

--- a/binds/python/bind_immutable.cpp
+++ b/binds/python/bind_immutable.cpp
@@ -36,7 +36,11 @@ void bind_immutable_module(py::module& m) {
              "Additional Ctor that accepts as filename any python object that implements __repr__ "
              "or __str__")
         .def("as_mutable",
-             [](const morphio::Morphology* morph) { return morphio::mut::Morphology(*morph); })
+             [](const morphio::Morphology& morph) {
+                 auto ptr = std::make_shared<morphio::mut::Morphology>();
+                 ptr->init(morph);
+                 return ptr;
+             })
 
         // Cell sub-parts accessors
         .def_property_readonly("soma", &morphio::Morphology::soma, "Returns the soma object")

--- a/binds/python/bind_mutable.cpp
+++ b/binds/python/bind_mutable.cpp
@@ -21,21 +21,34 @@ void bind_mutable_module(py::module& m) {
     using namespace py::literals;
 
 
-    py::class_<morphio::mut::Morphology>(m, "Morphology")
+    py::class_<morphio::mut::Morphology, std::shared_ptr<morphio::mut::Morphology>>(m, "Morphology")
         .def(py::init<>())
-        .def(py::init<const std::string&, unsigned int>(),
+        .def(py::init([](const std::string& filename, unsigned int options){
+            auto ptr = std::make_shared<morphio::mut::Morphology>();
+            ptr->init(filename, options);
+            return ptr;
+        }),
              "filename"_a,
              "options"_a = morphio::enums::Option::NO_MODIFIER)
-        .def(py::init<const morphio::Morphology&, unsigned int>(),
-             "morphology"_a,
-             "options"_a = morphio::enums::Option::NO_MODIFIER)
-        .def(py::init<const morphio::mut::Morphology&, unsigned int>(),
+        .def(py::init([](const morphio::Morphology& morph, unsigned int options) {
+            auto ptr = std::make_shared<morphio::mut::Morphology>();
+            ptr->init(morph, options);
+            return ptr;
+        }),
+            "morphology"_a,
+            "options"_a = morphio::enums::Option::NO_MODIFIER)
+        .def(py::init([](const morphio::mut::Morphology& morph, unsigned int options) {
+            auto ptr = std::make_shared<morphio::mut::Morphology>();
+            ptr->init(morph, options);
+            return ptr;
+        }),
              "morphology"_a,
              "options"_a = morphio::enums::Option::NO_MODIFIER)
         .def(py::init([](py::object arg, unsigned int options) {
-                 return std::unique_ptr<morphio::mut::Morphology>(
-                     new morphio::mut::Morphology(py::str(arg), options));
-             }),
+            auto ptr = std::make_shared<morphio::mut::Morphology>();
+            ptr->init(py::str(arg), options);
+            return ptr;
+        }),
              "filename"_a,
              "options"_a = morphio::enums::Option::NO_MODIFIER,
              "Additional Ctor that accepts as filename any python "
@@ -178,16 +191,17 @@ void bind_mutable_module(py::module& m) {
              "mutable_section"_a,
              "recursive"_a = false);
 
-    py::class_<morphio::mut::GlialCell, morphio::mut::Morphology>(m, "GlialCell")
+    py::class_<morphio::mut::GlialCell, morphio::mut::Morphology,
+               std::shared_ptr<morphio::mut::GlialCell>>(m, "GlialCell")
         .def(py::init<>())
-        .def(py::init<const std::string&>())
-        .def(py::init([](py::object arg) {
-                 return std::unique_ptr<morphio::mut::GlialCell>(
-                     new morphio::mut::GlialCell(py::str(arg)));
-             }),
-             "filename"_a,
-             "Additional Ctor that accepts as filename any python "
-             "object that implements __repr__ or __str__");
+        .def(py::init([](py::object arg, unsigned int options) {
+            auto ptr = std::make_shared<morphio::mut::GlialCell>();
+            ptr->init(py::str(arg), options);
+            return ptr;
+        }),
+            "filename"_a,
+            "options"_a = morphio::enums::Option::NO_MODIFIER,
+            "Ctor from a existing file");
 
 
     py::class_<morphio::mut::Mitochondria>(m, "Mitochondria")

--- a/binds/python/bind_mutable.cpp
+++ b/binds/python/bind_mutable.cpp
@@ -191,17 +191,18 @@ void bind_mutable_module(py::module& m) {
              "mutable_section"_a,
              "recursive"_a = false);
 
-    py::class_<morphio::mut::GlialCell, morphio::mut::Morphology,
+    py::class_<morphio::mut::GlialCell,
+               morphio::mut::Morphology,
                std::shared_ptr<morphio::mut::GlialCell>>(m, "GlialCell")
         .def(py::init<>())
         .def(py::init([](py::object arg, unsigned int options) {
-            auto ptr = std::make_shared<morphio::mut::GlialCell>();
-            ptr->init(py::str(arg), options);
-            return ptr;
-        }),
-            "filename"_a,
-            "options"_a = morphio::enums::Option::NO_MODIFIER,
-            "Ctor from a existing file");
+                 auto ptr = std::make_shared<morphio::mut::GlialCell>();
+                 ptr->init(py::str(arg), options);
+                 return ptr;
+             }),
+             "filename"_a,
+             "options"_a = morphio::enums::Option::NO_MODIFIER,
+             "Ctor from a existing file");
 
 
     py::class_<morphio::mut::Mitochondria>(m, "Mitochondria")

--- a/include/morphio/morphology.h
+++ b/include/morphio/morphology.h
@@ -39,7 +39,7 @@ class Morphology
      */
     explicit Morphology(const std::string& source, unsigned int options = NO_MODIFIER);
     explicit Morphology(const HighFive::Group& group, unsigned int options = NO_MODIFIER);
-    explicit Morphology(mut::Morphology);
+    explicit Morphology(const mut::Morphology&);
 
     /**
      * Return the soma object

--- a/include/morphio/mut/endoplasmic_reticulum.h
+++ b/include/morphio/mut/endoplasmic_reticulum.h
@@ -18,7 +18,6 @@ class EndoplasmicReticulum
                          const std::vector<morphio::floatType>& volumes,
                          const std::vector<morphio::floatType>& surfaceAreas,
                          const std::vector<uint32_t>& filamentCounts);
-    EndoplasmicReticulum(const EndoplasmicReticulum& endoplasmicReticulum);
     EndoplasmicReticulum(const morphio::EndoplasmicReticulum& endoplasmicReticulum);
 
 

--- a/include/morphio/mut/glial_cell.h
+++ b/include/morphio/mut/glial_cell.h
@@ -10,7 +10,7 @@ class GlialCell: public Morphology
 {
   public:
     GlialCell();
-    GlialCell(const std::string& source);
+    virtual void init(const std::string& uri, unsigned int options = NO_MODIFIER);
 };
 
 }  // namespace mut

--- a/include/morphio/mut/glial_cell.h
+++ b/include/morphio/mut/glial_cell.h
@@ -10,7 +10,7 @@ class GlialCell: public Morphology
 {
   public:
     GlialCell();
-    virtual void init(const std::string& uri, unsigned int options = NO_MODIFIER);
+    void init(const std::string& uri, unsigned int options = NO_MODIFIER);
 };
 
 }  // namespace mut

--- a/include/morphio/mut/morphology.h
+++ b/include/morphio/mut/morphology.h
@@ -23,7 +23,7 @@ namespace mut {
 bool _checkDuplicatePoint(const std::shared_ptr<Section>& parent,
                           const std::shared_ptr<Section>& current);
 
-class Morphology
+class Morphology : public std::enable_shared_from_this<Morphology>
 {
   public:
     Morphology()
@@ -31,6 +31,13 @@ class Morphology
         , _soma(std::make_shared<Soma>())
         , _cellProperties(
               std::make_shared<morphio::Property::CellLevel>(morphio::Property::CellLevel())) {}
+
+    /*
+     * Since the Morphology object must always live in a shared pointer
+     * we need to prevent its construction from implicit ctors.
+     */
+    Morphology(const Morphology&) = delete;
+    Morphology(const Morphology&&) = delete;
 
     /**
        Build a mutable Morphology from an on-disk morphology
@@ -41,17 +48,17 @@ class Morphology
        Example:
            Morphology("neuron.asc", TWO_POINTS_SECTIONS | SOMA_SPHERE);
     **/
-    Morphology(const std::string& uri, unsigned int options = NO_MODIFIER);
+    virtual void init(const std::string& uri, unsigned int options = NO_MODIFIER);
 
     /**
        Build a mutable Morphology from a mutable morphology
     **/
-    Morphology(const morphio::mut::Morphology& morphology, unsigned int options = NO_MODIFIER);
+    virtual void init(const morphio::mut::Morphology& morphology, unsigned int options = NO_MODIFIER);
 
     /**
        Build a mutable Morphology from a read-only morphology
     **/
-    Morphology(const morphio::Morphology& morphology, unsigned int options = NO_MODIFIER);
+    virtual void init(const morphio::Morphology& morphology, unsigned int options = NO_MODIFIER);
 
     virtual ~Morphology();
 
@@ -221,7 +228,7 @@ class Morphology
                      morphio::enums::LogLevel verbose);
     morphio::readers::ErrorMessages _err;
 
-    uint32_t _register(const std::shared_ptr<Section>&);
+    uint32_t _register(std::shared_ptr<Section>);
 
     uint32_t _counter;
     std::shared_ptr<Soma> _soma;

--- a/include/morphio/mut/morphology.h
+++ b/include/morphio/mut/morphology.h
@@ -48,17 +48,17 @@ class Morphology : public std::enable_shared_from_this<Morphology>
        Example:
            Morphology("neuron.asc", TWO_POINTS_SECTIONS | SOMA_SPHERE);
     **/
-    virtual void init(const std::string& uri, unsigned int options = NO_MODIFIER);
+    void init(const std::string& uri, unsigned int options = NO_MODIFIER);
 
     /**
        Build a mutable Morphology from a mutable morphology
     **/
-    virtual void init(const morphio::mut::Morphology& morphology, unsigned int options = NO_MODIFIER);
+    void init(const morphio::mut::Morphology& morphology, unsigned int options = NO_MODIFIER);
 
     /**
        Build a mutable Morphology from a read-only morphology
     **/
-    virtual void init(const morphio::Morphology& morphology, unsigned int options = NO_MODIFIER);
+    void init(const morphio::Morphology& morphology, unsigned int options = NO_MODIFIER);
 
     virtual ~Morphology();
 

--- a/include/morphio/mut/morphology.h
+++ b/include/morphio/mut/morphology.h
@@ -23,7 +23,7 @@ namespace mut {
 bool _checkDuplicatePoint(const std::shared_ptr<Section>& parent,
                           const std::shared_ptr<Section>& current);
 
-class Morphology : public std::enable_shared_from_this<Morphology>
+class Morphology: public std::enable_shared_from_this<Morphology>
 {
   public:
     Morphology()

--- a/include/morphio/mut/section.h
+++ b/include/morphio/mut/section.h
@@ -97,7 +97,10 @@ class Section: public std::enable_shared_from_this<Section>
   private:
     friend class Morphology;
 
-    Section(std::weak_ptr<Morphology>, unsigned int id, SectionType type, const Property::PointLevel&);
+    Section(std::weak_ptr<Morphology>,
+            unsigned int id,
+            SectionType type,
+            const Property::PointLevel&);
     Section(std::weak_ptr<Morphology>, unsigned int id, const morphio::Section& section);
     Section(std::weak_ptr<Morphology>, unsigned int id, const Section&);
 

--- a/include/morphio/mut/section.h
+++ b/include/morphio/mut/section.h
@@ -59,11 +59,6 @@ class Section: public std::enable_shared_from_this<Section>
     inline Property::PointLevel& properties() noexcept;
     inline const Property::PointLevel& properties() const noexcept;
     /** @} */
-    ////////////////////////////////////////////////////////////////////////////////
-    //
-    // Methods that were previously in mut::Morphology
-    //
-    ////////////////////////////////////////////////////////////////////////////////
 
     /**
        Get the parent ID
@@ -102,11 +97,17 @@ class Section: public std::enable_shared_from_this<Section>
   private:
     friend class Morphology;
 
-    Section(Morphology*, unsigned int id, SectionType type, const Property::PointLevel&);
-    Section(Morphology*, unsigned int id, const morphio::Section& section);
-    Section(Morphology*, unsigned int id, const Section&);
+    Section(std::weak_ptr<Morphology>, unsigned int id, SectionType type, const Property::PointLevel&);
+    Section(std::weak_ptr<Morphology>, unsigned int id, const morphio::Section& section);
+    Section(std::weak_ptr<Morphology>, unsigned int id, const Section&);
 
-    Morphology* _morphology;
+    /*
+      Getter of the Morphology object.
+      Will raise if the Morphology no longer exists
+     */
+    std::shared_ptr<Morphology> _getMorphology() const;
+
+    std::weak_ptr<Morphology> _morphology;
     Property::PointLevel _pointProperties;
     uint32_t _id;
     SectionType _sectionType;

--- a/morphio/mut/__init__.py
+++ b/morphio/mut/__init__.py
@@ -1,2 +1,2 @@
-from .._morphio.mut import (Morphology, Section, Soma, MitoSection,
-                            Mitochondria, GlialCell, EndoplasmicReticulum)
+from .._morphio.mut import Mitochondria, GlialCell
+from .._morphio.mut import EndoplasmicReticulum, MitoSection, Morphology, Section, Soma

--- a/src/morphology.cpp
+++ b/src/morphology.cpp
@@ -33,12 +33,13 @@ Morphology::Morphology(const Property::Properties& properties, unsigned int opti
     // For SWC and ASC, sanitization and modifier application are already taken care of by
     // their respective loaders
     if (properties._cellLevel.fileFormat() == "h5") {
-        mut::Morphology mutable_morph(*this);
-        mutable_morph.sanitize();
+        auto mutable_morph = std::make_shared<mut::Morphology>();
+        mutable_morph->init(*this);
+        mutable_morph->sanitize();
         if (options) {
-            mutable_morph.applyModifiers(options);
+            mutable_morph->applyModifiers(options);
         }
-        _properties = std::make_shared<Property::Properties>(mutable_morph.buildReadOnly());
+        _properties = std::make_shared<Property::Properties>(mutable_morph->buildReadOnly());
         buildChildren(_properties);
     }
 }
@@ -49,9 +50,11 @@ Morphology::Morphology(const HighFive::Group& group, unsigned int options)
 Morphology::Morphology(const std::string& source, unsigned int options)
     : Morphology(loadURI(source, options), options) {}
 
-Morphology::Morphology(mut::Morphology morphology) {
-    morphology.sanitize();
-    _properties = std::make_shared<Property::Properties>(morphology.buildReadOnly());
+Morphology::Morphology(const mut::Morphology& morphology) {
+    auto morph = std::make_shared<mut::Morphology>();
+    morph->init(morphology);
+    morph->sanitize();
+    _properties = std::make_shared<Property::Properties>(morph->buildReadOnly());
     buildChildren(_properties);
 }
 

--- a/src/mut/endoplasmic_reticulum.cpp
+++ b/src/mut/endoplasmic_reticulum.cpp
@@ -14,9 +14,6 @@ EndoplasmicReticulum::EndoplasmicReticulum(const std::vector<uint32_t>& sectionI
     _properties._filamentCounts = filamentCounts;
 }
 
-EndoplasmicReticulum::EndoplasmicReticulum(const EndoplasmicReticulum& endoplasmicReticulum)
-    : _properties(endoplasmicReticulum._properties) {}
-
 EndoplasmicReticulum::EndoplasmicReticulum(
     const morphio::EndoplasmicReticulum& endoplasmicReticulum)
     : _properties(endoplasmicReticulum._properties->_endoplasmicReticulumLevel) {}

--- a/src/mut/glial_cell.cpp
+++ b/src/mut/glial_cell.cpp
@@ -8,8 +8,8 @@ GlialCell::GlialCell()
     _cellProperties->_cellFamily = CellFamily::GLIA;
 }
 
-GlialCell::GlialCell(const std::string& source)
-    : Morphology(source) {
+void GlialCell::init(const std::string& source, unsigned int options) {
+    Morphology::init(source, options);
     if (_cellProperties->_cellFamily != CellFamily::GLIA)
         throw(RawDataError("File: " + source +
                            " is not a GlialCell file. It should be a H5 file the cell type GLIA."));

--- a/src/mut/morphology.cpp
+++ b/src/mut/morphology.cpp
@@ -28,8 +28,7 @@ void Morphology::init(const morphio::mut::Morphology& morphology, unsigned int o
     _soma = morphology.soma();
     _endoplasmicReticulum = morphology.endoplasmicReticulum();
 
-    _cellProperties = std::make_shared<morphio::Property::CellLevel>(
-        *morphology._cellProperties);
+    _cellProperties = std::make_shared<morphio::Property::CellLevel>(*morphology._cellProperties);
 
     for (const auto& root : morphology.rootSections()) {
         appendRootSection(root, true);
@@ -42,8 +41,7 @@ void Morphology::init(const morphio::mut::Morphology& morphology, unsigned int o
     applyModifiers(options);
 }
 
-void Morphology::init(const morphio::Morphology& morphology,
-                      unsigned int options) {
+void Morphology::init(const morphio::Morphology& morphology, unsigned int options) {
     _soma = std::make_shared<Soma>(morphology.soma());
     _endoplasmicReticulum = morphology.endoplasmicReticulum();
 
@@ -93,8 +91,7 @@ bool _checkDuplicatePoint(const std::shared_ptr<Section>& parent,
 std::shared_ptr<Section> Morphology::appendRootSection(const morphio::Section& section_,
                                                        bool recursive) {
     const std::shared_ptr<Section> ptr(
-        new Section(std::weak_ptr<Morphology>(shared_from_this()),
-                    _counter, section_));
+        new Section(std::weak_ptr<Morphology>(shared_from_this()), _counter, section_));
     _register(ptr);
     _rootSections.push_back(ptr);
 
@@ -114,8 +111,7 @@ std::shared_ptr<Section> Morphology::appendRootSection(const morphio::Section& s
 std::shared_ptr<Section> Morphology::appendRootSection(const std::shared_ptr<Section>& section_,
                                                        bool recursive) {
     const std::shared_ptr<Section> section_copy(
-        new Section(std::weak_ptr<Morphology>(shared_from_this()),
-                    _counter, *section_));
+        new Section(std::weak_ptr<Morphology>(shared_from_this()), _counter, *section_));
     _register(section_copy);
     _rootSections.push_back(section_copy);
 
@@ -135,9 +131,8 @@ std::shared_ptr<Section> Morphology::appendRootSection(const std::shared_ptr<Sec
 
 std::shared_ptr<Section> Morphology::appendRootSection(const Property::PointLevel& pointProperties,
                                                        SectionType type) {
-    const std::shared_ptr<Section> ptr(
-        new Section(std::weak_ptr<Morphology>(shared_from_this()),
-                    _counter, type, pointProperties));
+    const std::shared_ptr<Section> ptr(new Section(
+        std::weak_ptr<Morphology>(shared_from_this()), _counter, type, pointProperties));
     _register(ptr);
     _rootSections.push_back(ptr);
 
@@ -166,8 +161,7 @@ static void eraseByValue(std::vector<std::shared_ptr<Section>>& vec,
 }
 
 
-void Morphology::deleteSection(const std::shared_ptr<Section>& section_, bool recursive)
-{
+void Morphology::deleteSection(const std::shared_ptr<Section>& section_, bool recursive) {
     if (!section_)
         return;
     unsigned int id = section_->id();

--- a/src/mut/section.cpp
+++ b/src/mut/section.cpp
@@ -30,7 +30,10 @@ Section::Section(std::weak_ptr<Morphology> morphology,
     : _morphology(morphology)
     , _pointProperties(pointProperties)
     , _id(id_)
-    , _sectionType(type_) {}
+    , _sectionType(type_) {
+    // Sanity check that the morphology is alive
+    _getMorphology();
+}
 
 Section::Section(std::weak_ptr<Morphology> morphology,
                  unsigned int id_,
@@ -38,13 +41,19 @@ Section::Section(std::weak_ptr<Morphology> morphology,
     : Section(morphology,
               id_,
               section_.type(),
-              Property::PointLevel(section_._properties->_pointLevel, section_._range)) {}
+              Property::PointLevel(section_._properties->_pointLevel, section_._range)) {
+    // Sanity check that the morphology is alive
+    _getMorphology();
+}
 
 Section::Section(std::weak_ptr<Morphology> morphology, unsigned int id_, const Section& section_)
     : _morphology(morphology)
     , _pointProperties(section_._pointProperties)
     , _id(id_)
-    , _sectionType(section_._sectionType) {}
+    , _sectionType(section_._sectionType) {
+    // Sanity check that the morphology is alive
+    _getMorphology();
+}
 
 const std::shared_ptr<Section>& Section::parent() const {
     auto morph = _getMorphology();

--- a/src/mut/section.cpp
+++ b/src/mut/section.cpp
@@ -18,9 +18,9 @@ std::shared_ptr<Morphology> Section::_getMorphology() const {
     if (shared)
         return shared;
     else
-        throw std::runtime_error(
-            "This section (id: " + std::to_string(id()) + ") can no longer be used in the context of the whole morphology "
-            "because the Morphology object it belongs to has been deleted");
+        throw std::runtime_error("This section (id: " + std::to_string(id()) +
+                                 ") can no longer be used in the context of the whole morphology "
+                                 "because the Morphology object it belongs to has been deleted");
 }
 
 Section::Section(std::weak_ptr<Morphology> morphology,
@@ -32,7 +32,9 @@ Section::Section(std::weak_ptr<Morphology> morphology,
     , _id(id_)
     , _sectionType(type_) {}
 
-Section::Section(std::weak_ptr<Morphology> morphology, unsigned int id_, const morphio::Section& section_)
+Section::Section(std::weak_ptr<Morphology> morphology,
+                 unsigned int id_,
+                 const morphio::Section& section_)
     : Section(morphology,
               id_,
               section_.type(),
@@ -119,8 +121,7 @@ std::shared_ptr<Section> Section::appendSection(const std::shared_ptr<Section>& 
     if (!ErrorMessages::isIgnored(Warning::WRONG_DUPLICATE) && !emptySection &&
         !_checkDuplicatePoint(_sections[parentId], _sections[childId])) {
         printError(Warning::WRONG_DUPLICATE,
-                   morph->_err.WARNING_WRONG_DUPLICATE(_sections[childId],
-                                                             _sections.at(parentId)));
+                   morph->_err.WARNING_WRONG_DUPLICATE(_sections[childId], _sections.at(parentId)));
     }
 
     morph->_parent[childId] = parentId;
@@ -137,8 +138,7 @@ std::shared_ptr<Section> Section::appendSection(const std::shared_ptr<Section>& 
 
 std::shared_ptr<Section> Section::appendSection(const morphio::Section& section, bool recursive) {
     auto morph = _getMorphology();
-    const std::shared_ptr<Section> ptr(new Section(_morphology,
-                                                   morph->_counter, section));
+    const std::shared_ptr<Section> ptr(new Section(_morphology, morph->_counter, section));
     unsigned int parentId = id();
     uint32_t childId = morph->_register(ptr);
     auto& _sections = morph->_sections;
@@ -151,8 +151,7 @@ std::shared_ptr<Section> Section::appendSection(const morphio::Section& section,
     if (!ErrorMessages::isIgnored(Warning::WRONG_DUPLICATE) && !emptySection &&
         !_checkDuplicatePoint(_sections[parentId], _sections[childId]))
         printError(Warning::WRONG_DUPLICATE,
-                   morph->_err.WARNING_WRONG_DUPLICATE(_sections[childId],
-                                                             _sections.at(parentId)));
+                   morph->_err.WARNING_WRONG_DUPLICATE(_sections[childId], _sections.at(parentId)));
 
     morph->_parent[childId] = parentId;
     morph->_children[parentId].push_back(ptr);
@@ -191,8 +190,7 @@ std::shared_ptr<Section> Section::appendSection(const Property::PointLevel& poin
     if (!ErrorMessages::isIgnored(Warning::WRONG_DUPLICATE) && !emptySection &&
         !_checkDuplicatePoint(_sections[parentId], _sections[childId]))
         printError(Warning::WRONG_DUPLICATE,
-                   morph->_err.WARNING_WRONG_DUPLICATE(_sections[childId],
-                                                             _sections[parentId]));
+                   morph->_err.WARNING_WRONG_DUPLICATE(_sections[childId], _sections[parentId]));
 
     morph->_parent[childId] = parentId;
     morph->_children[parentId].push_back(ptr);

--- a/src/mut/section.cpp
+++ b/src/mut/section.cpp
@@ -23,7 +23,7 @@ std::shared_ptr<Morphology> Section::_getMorphology() const {
             "because the Morphology object it belongs to has been deleted");
 }
 
-Section::Section(std::weak_ptr<Morphology>(morphology),
+Section::Section(std::weak_ptr<Morphology> morphology,
                  unsigned int id_,
                  SectionType type_,
                  const Property::PointLevel& pointProperties)

--- a/tests/test_5_mut.py
+++ b/tests/test_5_mut.py
@@ -16,7 +16,7 @@ from .utils import assert_substring, captured_output, setup_tempdir, tmp_asc_fil
 
 DATA_DIR = Path(__file__).parent / 'data'
 
-SIMPLE = Morphology(str(Path(DATA_DIR, "simple.swc")))
+SIMPLE = Morphology(Path(DATA_DIR, "simple.swc"))
 
 
 def test_point_level():
@@ -155,7 +155,7 @@ def test_append_no_duplicate():
 
 
 def test_mut_copy_ctor():
-    simple = Morphology(str(Path(DATA_DIR, "simple.swc")))
+    simple = Morphology(Path(DATA_DIR, "simple.swc"))
     assert_equal([sec.id for sec in simple.iter()],
                  [0, 1, 2, 3, 4, 5])
     copy = Morphology(simple)
@@ -495,9 +495,3 @@ def test_lifetime_issue():
     assert_substring("This section (id: 0) can no longer be used in the context of the whole "
                      "morphology because the Morphology object it belongs to has been deleted",
                      str(obj.exception))
-
-def test_simple():
-    simple = Morphology(str(Path(DATA_DIR, "simple.swc")))
-
-if __name__ == '__main__':
-    test_simple()

--- a/tests/test_morphology.cpp
+++ b/tests/test_morphology.cpp
@@ -3,35 +3,38 @@
 
 #include <highfive/H5File.hpp>
 #include <morphio/morphology.h>
+#include <morphio/mut/morphology.h>
 
 
-TEST_CASE("LoadH5Morphology", "[morphology]") {
-    const morphio::Morphology m("data/h5/v1/Neuron.h5");
+// TEST_CASE("LoadH5Morphology", "[morphology]") {
+//     const morphio::Morphology m("/home/bcoste/workspace/io/tests/data/h5/v1/Neuron.h5");
 
-    REQUIRE(m.diameters().size() == 924);
-}
+//     REQUIRE(m.diameters().size() == 924);
+// }
 
 TEST_CASE("LoadSWCMorphology", "[morphology]") {
-    const morphio::Morphology m("data/simple.swc");
+    const auto& immut = morphio::Morphology("/home/bcoste/workspace/io/tests/data/simple.swc");
+    std::shared_ptr<morphio::mut::Morphology> m;
+    m = morphio::mut::Morphology::fromImmut(immut);
 
-    REQUIRE(m.diameters().size() == 12);
+    REQUIRE(m->section(0)->children().size() == 12);
 }
 
-TEST_CASE("LoadNeurolucidaMorphology", "[morphology]") {
-    const morphio::Morphology m("data/multiple_point_section.asc");
+// TEST_CASE("LoadNeurolucidaMorphology", "[morphology]") {
+//     const morphio::Morphology m("data/multiple_point_section.asc");
 
-    REQUIRE(m.diameters().size() == 14);
-}
+//     REQUIRE(m.diameters().size() == 14);
+// }
 
-TEST_CASE("LoadBadDimensionMorphology", "[morphology]") {
-    REQUIRE_THROWS(morphio::Morphology("data/h5/v1/monodim.h5"));
-}
+// TEST_CASE("LoadBadDimensionMorphology", "[morphology]") {
+//     REQUIRE_THROWS(morphio::Morphology("data/h5/v1/monodim.h5"));
+// }
 
-TEST_CASE("LoadMergedMorphology", "[morphology]") {
-    auto file = HighFive::File("data/h5/merged.h5", HighFive::File::ReadOnly);
-    REQUIRE_NOTHROW(morphio::readers::h5::MorphologyHDF5(
-        file.getGroup("/00/00/00000009b4fa102d58b173a995525c3e")));
-    auto g = file.getGroup("/00/00/00000009b4fa102d58b173a995525c3e");
-    morphio::Morphology m(g);
-    REQUIRE(m.rootSections().size() == 8);
-}
+// TEST_CASE("LoadMergedMorphology", "[morphology]") {
+//     auto file = HighFive::File("data/h5/merged.h5", HighFive::File::ReadOnly);
+//     REQUIRE_NOTHROW(morphio::readers::h5::MorphologyHDF5(
+//         file.getGroup("/00/00/00000009b4fa102d58b173a995525c3e")));
+//     auto g = file.getGroup("/00/00/00000009b4fa102d58b173a995525c3e");
+//     morphio::Morphology m(g);
+//     REQUIRE(m.rootSections().size() == 8);
+// }

--- a/tests/test_morphology.cpp
+++ b/tests/test_morphology.cpp
@@ -3,38 +3,35 @@
 
 #include <highfive/H5File.hpp>
 #include <morphio/morphology.h>
-#include <morphio/mut/morphology.h>
 
 
-// TEST_CASE("LoadH5Morphology", "[morphology]") {
-//     const morphio::Morphology m("/home/bcoste/workspace/io/tests/data/h5/v1/Neuron.h5");
+TEST_CASE("LoadH5Morphology", "[morphology]") {
+    const morphio::Morphology m("data/h5/v1/Neuron.h5");
 
-//     REQUIRE(m.diameters().size() == 924);
-// }
-
-TEST_CASE("LoadSWCMorphology", "[morphology]") {
-    const auto& immut = morphio::Morphology("/home/bcoste/workspace/io/tests/data/simple.swc");
-    std::shared_ptr<morphio::mut::Morphology> m;
-    m = morphio::mut::Morphology::fromImmut(immut);
-
-    REQUIRE(m->section(0)->children().size() == 12);
+    REQUIRE(m.diameters().size() == 924);
 }
 
-// TEST_CASE("LoadNeurolucidaMorphology", "[morphology]") {
-//     const morphio::Morphology m("data/multiple_point_section.asc");
+TEST_CASE("LoadSWCMorphology", "[morphology]") {
+    const morphio::Morphology m("data/simple.swc");
 
-//     REQUIRE(m.diameters().size() == 14);
-// }
+    REQUIRE(m.diameters().size() == 12);
+}
 
-// TEST_CASE("LoadBadDimensionMorphology", "[morphology]") {
-//     REQUIRE_THROWS(morphio::Morphology("data/h5/v1/monodim.h5"));
-// }
+TEST_CASE("LoadNeurolucidaMorphology", "[morphology]") {
+    const morphio::Morphology m("data/multiple_point_section.asc");
 
-// TEST_CASE("LoadMergedMorphology", "[morphology]") {
-//     auto file = HighFive::File("data/h5/merged.h5", HighFive::File::ReadOnly);
-//     REQUIRE_NOTHROW(morphio::readers::h5::MorphologyHDF5(
-//         file.getGroup("/00/00/00000009b4fa102d58b173a995525c3e")));
-//     auto g = file.getGroup("/00/00/00000009b4fa102d58b173a995525c3e");
-//     morphio::Morphology m(g);
-//     REQUIRE(m.rootSections().size() == 8);
-// }
+    REQUIRE(m.diameters().size() == 14);
+}
+
+TEST_CASE("LoadBadDimensionMorphology", "[morphology]") {
+    REQUIRE_THROWS(morphio::Morphology("data/h5/v1/monodim.h5"));
+}
+
+TEST_CASE("LoadMergedMorphology", "[morphology]") {
+    auto file = HighFive::File("data/h5/merged.h5", HighFive::File::ReadOnly);
+    REQUIRE_NOTHROW(morphio::readers::h5::MorphologyHDF5(
+        file.getGroup("/00/00/00000009b4fa102d58b173a995525c3e")));
+    auto g = file.getGroup("/00/00/00000009b4fa102d58b173a995525c3e");
+    morphio::Morphology m(g);
+    REQUIRE(m.rootSections().size() == 8);
+}


### PR DESCRIPTION
mut::Morphology dtor no longer calls mut::Section dtors. Instead it unlinks them
so they become flagged as unusable. Any attempt to use them will result in an
RuntimeError exception.

The python garbage collector becomes the guarantor of the sections deletion.