### PR TITLE
MorphIO no longer merge unifurcations

### DIFF
--- a/binds/python/bind_mutable.cpp
+++ b/binds/python/bind_mutable.cpp
@@ -131,9 +131,9 @@ void bind_mutable_module(py::module& m) {
 
         .def_property_readonly("version", &morphio::mut::Morphology::version, "Returns the version")
 
-        .def("sanitize",
+        .def("remove_unifurcations",
              static_cast<void (morphio::mut::Morphology::*) ()>(
-                 &morphio::mut::Morphology::sanitize),
+                 &morphio::mut::Morphology::removeUnifurcations),
              "Fixes the morphology single child sections and issues warnings"
              "if the section starts and ends are inconsistent")
 

--- a/doc/source/specification_neurolucida.rst
+++ b/doc/source/specification_neurolucida.rst
@@ -9,12 +9,6 @@ Soma
   ASC files with *multiple* CellBody tags will raise an error.
   `Unit test <https://github.com/BlueBrain/MorphIO/blob/5e111f3141f7a1ee72e0260111ce569741d80acb/tests/test_neurolucida.py#L58>`_
 
-Ignored keywords
-----------------
-
-All S-expressions starting with a keyword other than ``CellBody, Axon, Dendrite, Apical`` will be
-skipped.
-
 Duplicate points
 ----------------
 

--- a/include/morphio/errorMessages.h
+++ b/include/morphio/errorMessages.h
@@ -180,6 +180,8 @@ class ErrorMessages
                                              size_t length2) const;
 
     std::string ERROR_PERIMETER_DATA_NOT_WRITABLE();
+    std::string ERROR_ONLY_CHILD_SWC_WRITER(unsigned int parentId) const;
+
 
     ////////////////////////////////////////////////////////////////////////////////
     //              WARNINGS

--- a/include/morphio/mut/morphology.h
+++ b/include/morphio/mut/morphology.h
@@ -213,6 +213,11 @@ class Morphology
     void removeUnifurcations();
     void removeUnifurcations(const morphio::readers::DebugInfo& debugInfo);
 
+    /**
+       Used before writing to SWC to check that there is no unifurcation
+     **/
+    bool _checkUnifurcations();
+
   public:
     friend class Section;
     friend void modifiers::nrn_order(morphio::mut::Morphology& morpho);

--- a/include/morphio/mut/morphology.h
+++ b/include/morphio/mut/morphology.h
@@ -216,7 +216,7 @@ class Morphology
     /**
        Used before writing to SWC to check that there is no unifurcation
      **/
-    bool _checkUnifurcations();
+    void _raiseIfUnifurcations();
 
   public:
     friend class Section;

--- a/include/morphio/mut/morphology.h
+++ b/include/morphio/mut/morphology.h
@@ -210,8 +210,8 @@ class Morphology
        Fixes the morphology single child sections and issues warnings
        if the section starts and ends are inconsistent
      **/
-    void sanitize();
-    void sanitize(const morphio::readers::DebugInfo& debugInfo);
+    void removeUnifurcations();
+    void removeUnifurcations(const morphio::readers::DebugInfo& debugInfo);
 
   public:
     friend class Section;

--- a/src/errorMessages.cpp
+++ b/src/errorMessages.cpp
@@ -215,6 +215,15 @@ std::string ErrorMessages::ERROR_PERIMETER_DATA_NOT_WRITABLE() {
     return "Cannot write a file with perimeter data to ASC or SWC format";
 }
 
+std::string ErrorMessages::ERROR_ONLY_CHILD_SWC_WRITER(unsigned int parentId) const {
+    return ("Section " + std::to_string(parentId) +
+            " has a single child section. "
+            "Single child section are not allowed when writing to SWC format. "
+            "Please sanitize the morphology first.\n"
+            "Tip: you can use 'removeUnifurcations() (C++) / remove_unifurcations() (python)'");
+}
+
+
 ////////////////////////////////////////////////////////////////////////////////
 //              WARNINGS
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/morphology.cpp
+++ b/src/morphology.cpp
@@ -34,7 +34,6 @@ Morphology::Morphology(const Property::Properties& properties, unsigned int opti
     // their respective loaders
     if (properties._cellLevel.fileFormat() == "h5") {
         mut::Morphology mutable_morph(*this);
-        mutable_morph.sanitize();
         if (options) {
             mutable_morph.applyModifiers(options);
         }
@@ -50,7 +49,6 @@ Morphology::Morphology(const std::string& source, unsigned int options)
     : Morphology(loadURI(source, options), options) {}
 
 Morphology::Morphology(mut::Morphology morphology) {
-    morphology.sanitize();
     _properties = std::make_shared<Property::Properties>(morphology.buildReadOnly());
     buildChildren(_properties);
 }

--- a/src/mut/morphology.cpp
+++ b/src/mut/morphology.cpp
@@ -206,11 +206,11 @@ void _appendProperties(Property::PointLevel& to, const Property::PointLevel& fro
         _appendVector(to._perimeters, from._perimeters, offset);
 }
 
-void Morphology::sanitize() {
-    sanitize(morphio::readers::DebugInfo());
+void Morphology::removeUnifurcations() {
+    removeUnifurcations(morphio::readers::DebugInfo());
 }
 
-void Morphology::sanitize(const morphio::readers::DebugInfo& debugInfo) {
+void Morphology::removeUnifurcations(const morphio::readers::DebugInfo& debugInfo) {
     morphio::readers::ErrorMessages err(debugInfo._filename);
 
     auto it = depth_begin();
@@ -368,7 +368,7 @@ void Morphology::write(const std::string& filename) {
         // the concept of section does not have any meaning for the file format.
         // And due to how the swc writer() works, the file needs to be cleaned
         // or the parent ID will be messed up
-        clean.sanitize();
+        clean.removeUnifurcations();
         writer::swc(clean, filename);
     } else
         throw UnknownFileType(_err.ERROR_WRONG_EXTENSION(filename));

--- a/src/mut/morphology.cpp
+++ b/src/mut/morphology.cpp
@@ -364,6 +364,10 @@ void Morphology::write(const std::string& filename) {
         writer::asc(*this, filename);
     else if (extension == ".swc") {
         morphio::mut::Morphology clean(*this);
+        // Due to the structure based on IDs and parent IDs of SWC
+        // the concept of section does not have any meaning for the file format.
+        // And due to how the swc writer() works, the file needs to be cleaned
+        // or the parent ID will be messed up
         clean.sanitize();
         writer::swc(clean, filename);
     } else

--- a/src/mut/morphology.cpp
+++ b/src/mut/morphology.cpp
@@ -260,7 +260,7 @@ void Morphology::removeUnifurcations(const morphio::readers::DebugInfo& debugInf
     }
 }
 
-bool Morphology::_checkUnifurcations() {
+void Morphology::_raiseIfUnifurcations() {
     for (auto it = depth_begin(); it != depth_end(); ++it) {
         std::shared_ptr<Section> section_ = *it;
         if (section_->isRoot())
@@ -380,7 +380,7 @@ void Morphology::write(const std::string& filename) {
     else if (extension == ".asc")
         writer::asc(*this, filename);
     else if (extension == ".swc") {
-        _checkUnifurcations();
+        _raiseIfUnifurcations();
         writer::swc(*this, filename);
     } else
         throw UnknownFileType(_err.ERROR_WRONG_EXTENSION(filename));

--- a/src/mut/morphology.cpp
+++ b/src/mut/morphology.cpp
@@ -350,10 +350,7 @@ void Morphology::write(const std::string& filename) {
 
     std::string extension;
 
-    morphio::mut::Morphology clean(*this);
-    clean.sanitize();
-
-    for (const auto& root : clean.rootSections()) {
+    for (const auto& root : rootSections()) {
         if (root->points().size() < 2)
             throw morphio::SectionBuilderError("Root sections must have at least 2 points");
     }
@@ -362,12 +359,14 @@ void Morphology::write(const std::string& filename) {
         extension += my_tolower(c);
 
     if (extension == ".h5")
-        writer::h5(clean, filename);
+        writer::h5(*this, filename);
     else if (extension == ".asc")
-        writer::asc(clean, filename);
-    else if (extension == ".swc")
+        writer::asc(*this, filename);
+    else if (extension == ".swc") {
+        morphio::mut::Morphology clean(*this);
+        clean.sanitize();
         writer::swc(clean, filename);
-    else
+    } else
         throw UnknownFileType(_err.ERROR_WRONG_EXTENSION(filename));
 }
 

--- a/src/readers/morphologyASC.cpp
+++ b/src/readers/morphologyASC.cpp
@@ -348,7 +348,6 @@ Property::Properties load(const std::string& uri, unsigned int options) {
     NeurolucidaParser parser(uri);
 
     morphio::mut::Morphology& nb_ = parser.parse();
-    nb_.sanitize(parser.debugInfo_);
     nb_.applyModifiers(options);
 
     Property::Properties properties = nb_.buildReadOnly();

--- a/src/readers/morphologySWC.cpp
+++ b/src/readers/morphologySWC.cpp
@@ -289,7 +289,6 @@ class SWCBuilder
         if (morph.soma()->points().size() == 3 && !neurite_wrong_root.empty())
             printError(morphio::WRONG_ROOT_POINT, err.WARNING_WRONG_ROOT_POINT(neurite_wrong_root));
 
-        morph.sanitize();
         morph.applyModifiers(options);
 
         Property::Properties properties = morph.buildReadOnly();

--- a/tests/test_0_API.py
+++ b/tests/test_0_API.py
@@ -32,7 +32,7 @@ def test_mut_immut_have_same_methods():
 
     only_in_immut = {'section_types', 'diameters', 'perimeters', 'points', 'section_offsets',
                      'as_mutable'}
-    only_in_mut = {'sanitize', 'write', 'append_root_section', 'delete_section', 'build_read_only',
+    only_in_mut = {'remove_unifurcations', 'write', 'append_root_section', 'delete_section', 'build_read_only',
                    'as_immutable'}
     assert_equal(methods(morphio.Morphology) - only_in_immut,
                  methods(morphio.mut.Morphology) - only_in_mut)

--- a/tests/test_2_neurolucida.py
+++ b/tests/test_2_neurolucida.py
@@ -332,7 +332,7 @@ def test_section_single_point():
 
 
 def test_single_children():
-    '''Single children are no longer merged with their parent
+    '''Single children are no longer (starting at v2.8) merged with their parent
 
     They used to be until the decision in:
     https://github.com/BlueBrain/MorphIO/issues/235
@@ -344,9 +344,9 @@ def test_single_children():
                       (3 -8 0 2)
                       (3 -10 0 2)
                       (
-                        (3 -10 0 4)  ; merged with parent section
-                        (0 -10 0 4)  ; merged with parent section
-                        (-3 -10 0 3) ; merged with parent section
+                        (3 -10 0 4)
+                        (0 -10 0 4)
+                        (-3 -10 0 3)
                         (
                           (-5 -5 5 5)
                           |

--- a/tests/test_3_h5.py
+++ b/tests/test_3_h5.py
@@ -3,8 +3,7 @@ from itertools import chain, repeat
 from pathlib import Path
 
 import requests
-from morphio import (CellFamily, Morphology, RawDataError, SectionType,
-                     ostream_redirect)
+from morphio import CellFamily, Morphology, RawDataError, SectionType, ostream_redirect
 from nose.tools import assert_equal, assert_raises, ok_
 from numpy.testing import assert_array_equal
 
@@ -85,4 +84,4 @@ def test_single_children():
     with captured_output() as (_, _):
         with ostream_redirect(stdout=True, stderr=True):
             neuron = Morphology(H5V1_PATH / 'two_child_unmerged.h5')
-    assert_equal(len(list(neuron.iter())), 3)
+    assert_equal(len(list(neuron.iter())), 8)

--- a/tests/test_5_mut.py
+++ b/tests/test_5_mut.py
@@ -2,24 +2,23 @@ import os
 from collections import OrderedDict
 
 import numpy as np
-from numpy.testing import assert_equal
 from nose.tools import assert_dict_equal, assert_raises, ok_
-from numpy.testing import assert_array_equal
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import morphio
-from morphio import MitochondriaPointLevel, MorphioError, RawDataError
+from morphio import CellFamily, IterType, MitochondriaPointLevel, MorphioError
 from morphio import Morphology as ImmutableMorphology
-from morphio import (PointLevel, SectionBuilderError, SectionType,
-                     IterType, ostream_redirect, CellFamily)
-from morphio.mut import Morphology, GlialCell
-from . utils import assert_substring, captured_output, tmp_asc_file, setup_tempdir
+from morphio import PointLevel, RawDataError, SectionBuilderError, SectionType, ostream_redirect
+from morphio.mut import GlialCell, Morphology
+from nose.tools import assert_dict_equal, assert_raises, ok_
+from numpy.testing import assert_array_equal, assert_equal
 
-_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
+from .utils import assert_substring, captured_output, setup_tempdir, tmp_asc_file
 
-DATA_DIR = Path(__file__).parent / 'data'
-SIMPLE = Morphology(os.path.join(_path, "simple.swc"))
+DATA_DIR = Path(__file__).parent /  "data"
+
+SIMPLE = Morphology(Path(DATA_DIR, "simple.swc"))
 
 
 def test_point_level():
@@ -48,9 +47,9 @@ def test_point_level():
 
 def test_connectivity():
     cells = OrderedDict({
-        'asc': Morphology(os.path.join(_path, "simple.asc")),
-        'swc': Morphology(os.path.join(_path, "simple.swc")),
-        'h5': Morphology(os.path.join(_path, "h5/v1/simple.h5")),
+        'asc': Morphology(Path(DATA_DIR, "simple.asc")),
+        'swc': Morphology(Path(DATA_DIR, "simple.swc")),
+        'h5': Morphology(Path(DATA_DIR, "h5/v1/simple.h5")),
     })
 
     for cell in cells:
@@ -158,7 +157,7 @@ def test_append_no_duplicate():
 
 
 def test_mut_copy_ctor():
-    simple = Morphology(os.path.join(_path, "simple.swc"))
+    simple = Morphology(Path(DATA_DIR, "simple.swc"))
     assert_equal([sec.id for sec in simple.iter()],
                  [0, 1, 2, 3, 4, 5])
     copy = Morphology(simple)
@@ -231,7 +230,7 @@ def test_build_read_only():
 
 
 def test_mutable_immutable_equivalence():
-    morpho = ImmutableMorphology(os.path.join(_path, "simple.swc"))
+    morpho = ImmutableMorphology(Path(DATA_DIR, "simple.swc"))
     assert_array_equal(morpho.points, morpho.as_mutable().as_immutable().points)
 
 
@@ -269,7 +268,7 @@ def test_sections_are_not_dereferenced():
     """There used to be a bug where if you would call:
     mitochondria.sections, that would dereference all section pointers
     if mitochondria.sections was not kept in a variable"""
-    morpho = Morphology(os.path.join(_path, "h5/v1/mitochondria.h5"))
+    morpho = Morphology(Path(DATA_DIR, "h5/v1/mitochondria.h5"))
 
     # This lines used to cause a bug
     morpho.mitochondria.sections  # pylint: disable=pointless-statement
@@ -345,7 +344,7 @@ def test_iterators():
     assert_array_equal([sec.id for sec in SIMPLE.iter(IterType.breadth_first)],
                        [0, 3, 1, 2, 4, 5])
 
-    neuron = Morphology(os.path.join(_path, "iterators.asc"))
+    neuron = Morphology(Path(DATA_DIR, "iterators.asc"))
     root = neuron.root_sections[0]
     assert_array_equal([section.id for section in root.iter(IterType.depth_first)],
                        [0, 1, 2, 3, 4, 5, 6])
@@ -356,7 +355,7 @@ def test_iterators():
                        [0, 7, 1, 4, 8, 9, 2, 3, 5, 6])
 
 def test_non_C_nparray():
-    m = Morphology(os.path.join(_path, "simple.swc"))
+    m = Morphology(Path(DATA_DIR, "simple.swc"))
     section = m.root_sections[0]
     points = np.array([[1, 2, 3], [4, 5, 6]])
     section.points = points
@@ -389,11 +388,70 @@ def test_annotation():
                       )
                  """) as tmp_file:
                 cell = Morphology(tmp_file.name)
+                cell.sanitize()
 
     for n in (cell, cell.as_immutable(), cell.as_immutable().as_mutable()):
         assert_equal(len(n.annotations), 1)
         annotation = n.annotations[0]
         assert_equal(annotation.type, morphio.AnnotationType.single_child)
+
+def test_empty_sibling():
+    '''The empty sibling will be removed and the single child will be merged
+    with its parent'''
+    with captured_output() as (_, err):
+        with ostream_redirect(stdout=True, stderr=True):
+            with tmp_asc_file('''((Dendrite)
+                      (3 -4 0 10)
+                      (3 -6 0 9)
+                      (3 -8 0 8)
+                      (3 -10 0 7)
+                      (
+                        (3 -10 0 6)
+                        (0 -10 0 5)
+                        (-3 -10 0 4)
+                        |       ; <-- empty sibling but still works !
+                       )
+                      )
+                 ''') as tmp_file:
+                n = Morphology(tmp_file.name)
+                n.sanitize()
+                assert_substring('is the only child of section: 0',
+                                 err.getvalue().strip())
+                assert_substring('It will be merged with the parent section',
+                                 err.getvalue().strip())
+
+    assert_equal(len(n.root_sections), 1)
+    assert_array_equal(n.root_sections[0].points,
+                       np.array([[3, -4, 0],
+                                 [3, -6, 0],
+                                 [3, -8, 0],
+                                 [3, -10, 0],
+                                 [0, -10, 0],
+                                 [-3, -10, 0]],
+                                dtype=np.float32))
+    assert_array_equal(n.root_sections[0].diameters,
+                       np.array([10, 9, 8, 7, 5, 4], dtype=np.float32))
+
+    assert_equal(len(n.annotations), 1)
+    annotation = n.annotations[0]
+    assert_equal(annotation.type, morphio.AnnotationType.single_child)
+    assert_equal(annotation.line_number, -1)
+    assert_array_equal(annotation.points, [[3, -10, 0], [0, -10, 0], [-3, -10, 0]])
+    assert_array_equal(annotation.diameters, [6, 5, 4])
+
+def test_nested_single_child():
+    with captured_output() as (_, err):
+        with ostream_redirect(stdout=True, stderr=True):
+            n = Morphology(DATA_DIR / 'nested_single_children.asc')
+            n.sanitize()
+    assert_array_equal(n.root_sections[0].points,
+                       [[0., 0., 0.],
+                        [0., 0., 1.],
+                        [0., 0., 2.],
+                        [0., 0., 3.],
+                        [0., 0., 4.]])
+    assert_array_equal(n.root_sections[0].diameters, np.array([8, 7, 6, 5, 4], dtype=np.float32))
+
 
 def test_section___str__():
     assert_equal(str(SIMPLE.root_sections[0]),
@@ -401,12 +459,12 @@ def test_section___str__():
 
 
 def test_from_pathlib():
-    neuron = Morphology(Path(_path, "simple.asc"))
+    neuron = Morphology(DATA_DIR / "simple.asc")
     assert_equal(len(neuron.root_sections), 2)
 
 
 def test_endoplasmic_reticulum():
-    neuron = Morphology(Path(_path, "simple.asc"))
+    neuron = Morphology(DATA_DIR / "simple.asc")
     reticulum = neuron.endoplasmic_reticulum
     assert_equal(reticulum.section_indices, [])
     assert_equal(reticulum.volumes, [])
@@ -493,19 +551,19 @@ def test_glia():
     g = GlialCell()
     assert_equal(g.cell_family, CellFamily.GLIA)
 
-    g = GlialCell(os.path.join(_path, 'astrocyte.h5'))
+    g = GlialCell(Path(DATA_DIR, 'astrocyte.h5'))
     assert_equal(g.cell_family, CellFamily.GLIA)
 
-    g = GlialCell(Path(_path, 'astrocyte.h5'))
+    g = GlialCell(DATA_DIR / 'astrocyte.h5')
     assert_equal(g.cell_family, CellFamily.GLIA)
 
-    assert_raises(RawDataError, GlialCell, Path(_path, 'simple.swc'))
-    assert_raises(RawDataError, GlialCell, Path(_path, 'h5/v1/simple.h5'))
+    assert_raises(RawDataError, GlialCell, DATA_DIR / 'simple.swc')
+    assert_raises(RawDataError, GlialCell, DATA_DIR / 'h5/v1/simple.h5')
 
 
 def test_glia_round_trip():
     with TemporaryDirectory() as folder:
-        g = GlialCell(os.path.join(_path, 'astrocyte.h5'))
+        g = GlialCell(Path(DATA_DIR, 'astrocyte.h5'))
         filename = Path(folder, 'glial-cell.h5')
         g.write(filename)
         g2 = GlialCell(filename)

--- a/tests/test_5_mut.py
+++ b/tests/test_5_mut.py
@@ -1,8 +1,6 @@
-import os
 from collections import OrderedDict
 
 import numpy as np
-from nose.tools import assert_dict_equal, assert_raises, ok_
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -16,7 +14,7 @@ from numpy.testing import assert_array_equal, assert_equal
 
 from .utils import assert_substring, captured_output, setup_tempdir, tmp_asc_file
 
-DATA_DIR = Path(__file__).parent /  "data"
+DATA_DIR = Path(__file__).parent / "data"
 
 SIMPLE = Morphology(Path(DATA_DIR, "simple.swc"))
 
@@ -236,7 +234,7 @@ def test_mutable_immutable_equivalence():
 
 def test_mitochondria_read():
     """Read a H5 file with a mitochondria"""
-    morpho = Morphology(os.path.join(_path, "h5/v1/mitochondria.h5"))
+    morpho = Morphology(DATA_DIR / "h5/v1/mitochondria.h5")
     mito = morpho.mitochondria
     assert_equal(len(mito.root_sections), 2)
 
@@ -439,6 +437,7 @@ def test_empty_sibling():
     assert_array_equal(annotation.points, [[3, -10, 0], [0, -10, 0], [-3, -10, 0]])
     assert_array_equal(annotation.diameters, [6, 5, 4])
 
+
 def test_nested_single_child():
     with captured_output() as (_, err):
         with ostream_redirect(stdout=True, stderr=True):
@@ -527,7 +526,7 @@ def test_remove_unifurcations():
 
 
 def test_remove_rootsection():
-    morpho = Morphology(os.path.join(_path, 'single_point_root.asc'))
+    morpho = Morphology(DATA_DIR / 'single_point_root.asc')
     assert_equal(len(morpho.root_sections), 1)
     to_remove = []
     for root in morpho.root_sections:
@@ -539,7 +538,7 @@ def test_remove_rootsection():
 
 
 def test_remove_rootsection_in_loop():
-    morpho = Morphology(os.path.join(_path, 'single_point_root.asc'))
+    morpho = Morphology(DATA_DIR / 'single_point_root.asc')
     assert_equal(len(morpho.root_sections), 1)
     for root in morpho.root_sections:
         if len(root.points) == 1:

--- a/tests/test_5_mut.py
+++ b/tests/test_5_mut.py
@@ -388,7 +388,7 @@ def test_annotation():
                       )
                  """) as tmp_file:
                 cell = Morphology(tmp_file.name)
-                cell.sanitize()
+                cell.remove_unifurcations()
 
     for n in (cell, cell.as_immutable(), cell.as_immutable().as_mutable()):
         assert_equal(len(n.annotations), 1)
@@ -414,7 +414,7 @@ def test_empty_sibling():
                       )
                  ''') as tmp_file:
                 n = Morphology(tmp_file.name)
-                n.sanitize()
+                n.remove_unifurcations()
                 assert_substring('is the only child of section: 0',
                                  err.getvalue().strip())
                 assert_substring('It will be merged with the parent section',
@@ -443,7 +443,7 @@ def test_nested_single_child():
     with captured_output() as (_, err):
         with ostream_redirect(stdout=True, stderr=True):
             n = Morphology(DATA_DIR / 'nested_single_children.asc')
-            n.sanitize()
+            n.remove_unifurcations()
     assert_array_equal(n.root_sections[0].points,
                        [[0., 0., 0.],
                         [0., 0., 1.],
@@ -493,7 +493,7 @@ def test_endoplasmic_reticulum():
     assert_equal(reticulum.filament_counts, [4, 4])
 
 
-def test_sanitize():
+def test_remove_unifurcations():
     m = Morphology()
     section = m.append_root_section(PointLevel([[1, 0, 0],
                                                 [2, 0, 0]], [2, 2], [20, 20]),
@@ -502,13 +502,13 @@ def test_sanitize():
                                        [3, 0, 0]], [2, 2], [20, 20]))
     with captured_output() as (_, err):
         with ostream_redirect(stdout=True, stderr=True):
-            m.sanitize()
+            m.remove_unifurcations()
             assert_equal(len(list(m.iter())), 1)
             assert_equal(err.getvalue().strip(),
                          'Warning: section 1 is the only child of section: 0\nIt will be merged '
                          'with the parent section')
 
-    # Checking that sanitize() issues a warning on missing duplicate
+    # Checking that remove_unifurcations() issues a warning on missing duplicate
     m = Morphology()
     section = m.append_root_section(PointLevel([[1, 0, 0],
                                                 [2, 0, 0]], [2, 2], [20, 20]),
@@ -521,7 +521,7 @@ def test_sanitize():
                                                [2, 0, 0]], [2, 2], [20, 20]))
     with captured_output() as (_, err):
         with ostream_redirect():
-            m.sanitize()
+            m.remove_unifurcations()
             assert_equal(err.getvalue().strip(),
                          'Warning: while appending section: 2 to parent: 0\nThe section first point should be parent section last point: \n        : X Y Z Diameter\nparent last point :[2.000000, 0.000000, 0.000000, 2.000000]\nchild first point :[2.000000, 1.000000, 0.000000, 2.000000]')
 

--- a/tests/test_6_writers.py
+++ b/tests/test_6_writers.py
@@ -79,19 +79,14 @@ def test_write_basic():
             ok_('/perimeters' not in h5_file.keys())
 
 
-def _morpho_with_unifurcation():
-    ''' Helper function that returns a morphology with a unifurcation
+def test_write_merge_only_child_asc_h5():
+    '''The root section has only one child
 
-                             o
-                            /
-                           / son 1
-      root       child    /
-    o--------o----------o<
-                          \
-                           \  son 2
-                            \
-                             o
+    When writing, children should *not* be merged with their parent section.
+
+    Note: See `test_write_merge_only_child_swc` for the SWC case.
     '''
+
     morpho = Morphology()
     morpho.soma.points = [[0, 0, 0]]
     morpho.soma.diameters = [2]
@@ -102,18 +97,6 @@ def _morpho_with_unifurcation():
                                             [2, 2]),
                                  SectionType.basal_dendrite)
     child = root.append_section(PointLevel([[0, 5, 0], [0, 6, 0]], [2, 3]))
-    return morpho
-
-
-def test_write_merge_only_child_asc_h5():
-    '''The root section has only one child
-
-    When writing, children should *not* be merged with their parent section.
-
-    Note: See `test_write_merge_only_child_swc` for the SWC case.
-    '''
-
-    morpho = _morpho_with_unifurcation()
     with setup_tempdir('test_write_merge_only_child') as tmp_folder:
         for extension in ['asc', 'h5']:
             with captured_output() as (_, err):
@@ -134,7 +117,17 @@ def test_write_merge_only_child_swc():
     '''Attempts to write a morphology with unifurcations with SWC should result
     in an exception.
     '''
-    morpho = _morpho_with_unifurcation()
+    morpho = Morphology()
+    morpho.soma.points = [[0, 0, 0]]
+    morpho.soma.diameters = [2]
+
+    root = morpho.append_root_section(
+                                 PointLevel([[0, 0, 0],
+                                             [0, 5, 0]],
+                                            [2, 2]),
+                                 SectionType.basal_dendrite)
+    child = root.append_section(PointLevel([[0, 5, 0], [0, 6, 0]], [2, 3]))
+
     with assert_raises(WriterError) as obj:
        morpho.write('/tmp/bla.swc')  # the path does not need to exists since it will fail before
     assert_substring("Section 0 has a single child section. "

--- a/tests/test_6_writers.py
+++ b/tests/test_6_writers.py
@@ -102,8 +102,6 @@ def _morpho_with_unifurcation():
                                             [2, 2]),
                                  SectionType.basal_dendrite)
     child = root.append_section(PointLevel([[0, 5, 0], [0, 6, 0]], [2, 3]))
-    son1 = child.append_section(PointLevel([[0, 6, 0], [0, 7, 0]], [2, 3]))
-    son2 = child.append_section(PointLevel([[0, 6, 0], [4, 5, 6]], [3, 3]))
     return morpho
 
 

--- a/tests/test_6_writers.py
+++ b/tests/test_6_writers.py
@@ -140,7 +140,7 @@ def test_write_merge_only_child_swc():
     with assert_raises(WriterError) as obj:
        morpho.write('/tmp/bla.swc')  # the path does not need to exists since it will fail before
     assert_substring("Section 0 has a single child section. "
-                     "Single child section are not allowed when writing to SWC. "
+                     "Single child section are not allowed when writing to SWC format. "
                      "Please sanitize the morphology first.",
                      str(obj.exception),)
 

--- a/tests/test_6_writers.py
+++ b/tests/test_6_writers.py
@@ -82,7 +82,11 @@ def test_write_basic():
 
 def test_write_merge_only_child():
     '''The root section has only one child
-    The child should be merged with its parent section
+
+    When writing, children should *not* be merged with their parent section.
+    Except if the output extension is SWC because we have no choice (there is no
+    way to represent single children in SWC)
+
     Special care must be given for the potential duplicate point
                              o
                             /
@@ -114,23 +118,33 @@ def test_write_merge_only_child():
                     filename = Path(tmp_folder, 'test.{}'.format(extension))
                     morpho.write(filename)
 
-                    assert_equal(err.getvalue().strip(),
-                                 'Warning: section 1 is the only child of section: 0\nIt will be merged with the parent section')
+                    if extension == 'swc':
+                        assert_equal(err.getvalue().strip(),
+                                     'Warning: section 1 is the only child of section: 0\nIt will be merged with the parent section')
 
 
             read = Morphology(filename)
-            root = read.root_sections[0]
-            assert_array_equal(root.points,
-                               [[0, 0, 0],
-                                [0, 5, 0],
-                                [0, 6, 0]])
-            assert_equal(len(root.children), 2)
 
-            assert_array_equal(root.children[0].points,
-                               [[0, 6, 0], [0, 7, 0]])
+            if extension != 'swc':
+                root = read.root_sections[0]
+                assert_array_equal(root.points,
+                                   [[0, 0, 0],
+                                    [0, 5, 0]])
+                assert_equal(len(root.children), 1)
 
-            assert_array_equal(root.children[1].points,
-                               [[0, 6, 0], [4, 5, 6]])
+            else:
+                root = read.root_sections[0]
+                assert_array_equal(root.points,
+                                   [[0, 0, 0],
+                                    [0, 5, 0],
+                                    [0, 6, 0]])
+                assert_equal(len(root.children), 2)
+
+                assert_array_equal(root.children[0].points,
+                                   [[0, 6, 0], [0, 7, 0]])
+
+                assert_array_equal(root.children[1].points,
+                                   [[0, 6, 0], [4, 5, 6]])
 
 
 


### PR DESCRIPTION
This is true for loading **and** writing.

To be precise, it still merges them when **writing in SWC format** but that's because we do
not have the choice.

Consequently this means the definition of a `section` has been changed to:

```
Section:
- A succession of points between two bifurcations if the file is in SWC format.
- A succession of points (not necessarily between two bifurcations) in an S-exp if the file is in ASC format.
- A succession of points (not necessarily between two bifurcations) corresponding to a block in an H5 format.
```

This is the outcome of the discussion that occured in #235 