### PR TITLE
simple lifetime check using nullptr

### DIFF
--- a/include/morphio/mut/morphology.h
+++ b/include/morphio/mut/morphology.h
@@ -233,6 +233,10 @@ class Morphology
 
     std::map<uint32_t, uint32_t> _parent;
     std::map<uint32_t, std::vector<std::shared_ptr<Section>>> _children;
+
+  private:
+    void eraseByValue(std::vector<std::shared_ptr<Section>>& vec,
+                      const std::shared_ptr<Section> section);
 };
 
 inline const std::vector<std::shared_ptr<Section>>& Morphology::rootSections() const noexcept {

--- a/include/morphio/mut/section.h
+++ b/include/morphio/mut/section.h
@@ -106,6 +106,12 @@ class Section: public std::enable_shared_from_this<Section>
     Section(Morphology*, unsigned int id, const morphio::Section& section);
     Section(Morphology*, unsigned int id, const Section&);
 
+
+    /**
+      Getter for _morphology; checks the pointer is non-null, throws otherwise
+    **/
+    Morphology* getOwningMorphologyOrThrow() const;
+
     Morphology* _morphology;
     Property::PointLevel _pointProperties;
     uint32_t _id;

--- a/include/morphio/mut/section.h
+++ b/include/morphio/mut/section.h
@@ -108,6 +108,11 @@ class Section: public std::enable_shared_from_this<Section>
 
 
     /**
+      If section is an orphan, in other words it does not belong to an a morphology
+    **/
+    void throwIfNoOwningMorphology() const;
+
+    /**
       Getter for _morphology; checks the pointer is non-null, throws otherwise
     **/
     Morphology* getOwningMorphologyOrThrow() const;

--- a/src/mut/morphology.cpp
+++ b/src/mut/morphology.cpp
@@ -153,14 +153,19 @@ Morphology::~Morphology() {
     }
 }
 
-static void eraseByValue(std::vector<std::shared_ptr<Section>>& vec,
-                         const std::shared_ptr<Section>& section) {
+void Morphology::eraseByValue(std::vector<std::shared_ptr<Section>>& vec,
+                              const std::shared_ptr<Section> section) {
+    if (section->_morphology == this) {
+        section->_morphology = nullptr;
+        section->_id = 0xffffffff;
+    }
     vec.erase(std::remove(vec.begin(), vec.end(), section), vec.end());
 }
 
 void Morphology::deleteSection(std::shared_ptr<Section> section_, bool recursive) {
     if (!section_)
         return;
+
     unsigned int id = section_->id();
 
     if (recursive) {

--- a/src/mut/section.cpp
+++ b/src/mut/section.cpp
@@ -34,10 +34,14 @@ Section::Section(Morphology* morphology, unsigned int id_, const Section& sectio
     , _id(id_)
     , _sectionType(section_._sectionType) {}
 
-Morphology* Section::getOwningMorphologyOrThrow() const {
+void Section::throwIfNoOwningMorphology() const {
     if (!_morphology) {
         throw std::runtime_error("Section does not belong to a morphology, impossible operation");
     }
+}
+
+Morphology* Section::getOwningMorphologyOrThrow() const {
+    throwIfNoOwningMorphology();
     return _morphology;
 }
 
@@ -67,26 +71,32 @@ const std::vector<std::shared_ptr<Section>>& Section::children() const {
 }
 
 depth_iterator Section::depth_begin() const {
+    throwIfNoOwningMorphology();
     return depth_iterator(const_cast<Section*>(this)->shared_from_this());
 }
 
 depth_iterator Section::depth_end() const {
+    throwIfNoOwningMorphology();
     return depth_iterator();
 }
 
 breadth_iterator Section::breadth_begin() const {
+    throwIfNoOwningMorphology();
     return breadth_iterator(const_cast<Section*>(this)->shared_from_this());
 }
 
 breadth_iterator Section::breadth_end() const {
+    throwIfNoOwningMorphology();
     return breadth_iterator();
 }
 
 upstream_iterator Section::upstream_begin() const {
+    throwIfNoOwningMorphology();
     return upstream_iterator(const_cast<Section*>(this)->shared_from_this());
 }
 
 upstream_iterator Section::upstream_end() const {
+    throwIfNoOwningMorphology();
     return upstream_iterator();
 }
 

--- a/tests/test_5_mut.py
+++ b/tests/test_5_mut.py
@@ -512,22 +512,23 @@ def test_glia_round_trip():
         assert_equal(len(g.sections), len(g2.sections))
 
 def _get_section():
+    '''this is used so that the reference to m is destroyed'''
     m = Morphology(DATA_DIR / 'simple.swc')
     s = m.root_sections[0]
     return s
 
-def test_lifetime_1():
-    '''Attempting to access topological information after a Morphology has been destroyed should
-    raise'''
+def test_lifetime_destroyed_morphology():
+    '''accessing topological info after a Morphology has been destroyed should raise'''
     m = Morphology(DATA_DIR / 'simple.swc')
     s = m.root_sections[0]
+
     del m # ~mut.Morphology() called
+
     with assert_raises(RuntimeError) as obj:
         s.children
 
-def test_lifetime_2():
-    '''Attempting to access topological information after a Morphology has been destroyed should
-    raise'''
+def test_lifetime_destroyed_morphology():
+    '''accessing topological info after a Morphology has been destroyed should raise'''
     section = _get_section()
     assert_array_equal(section.points,
                        np.array([[0., 0., 0.],
@@ -536,9 +537,9 @@ def test_lifetime_2():
     with assert_raises(RuntimeError) as obj:
         section.children
 
-def test_lifetime_3():
-    '''Copy a section from a destroyed morphology should work because it does not use any
-    topological information'''
+def test_lifetime_copy_single_section():
+    '''Copying a single section from a destroyed morphology works because it
+    does not use any topological information'''
     section = _get_section()
 
     # Proof that the morphology has really been destroyed
@@ -552,3 +553,9 @@ def test_lifetime_3():
     assert_array_equal(morph.root_sections[0].points,
                        np.array([[0., 0., 0.],
                                  [0., 5., 0.]], dtype=np.float32))
+
+def test_lifetime_iteration_fails_with_orphan_section():
+    section = _get_section()
+    for iter_type in IterType.depth_first, IterType.breadth_first, IterType.upstream:
+        with assert_raises(RuntimeError) as obj:
+            section.iter(iter_type)

--- a/tests/test_5_mut.py
+++ b/tests/test_5_mut.py
@@ -18,6 +18,7 @@ from . utils import assert_substring, captured_output, tmp_asc_file, setup_tempd
 
 _path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
 
+DATA_DIR = Path(__file__).parent / 'data'
 SIMPLE = Morphology(os.path.join(_path, "simple.swc"))
 
 
@@ -509,3 +510,45 @@ def test_glia_round_trip():
         g.write(filename)
         g2 = GlialCell(filename)
         assert_equal(len(g.sections), len(g2.sections))
+
+def _get_section():
+    m = Morphology(DATA_DIR / 'simple.swc')
+    s = m.root_sections[0]
+    return s
+
+def test_lifetime_1():
+    '''Attempting to access topological information after a Morphology has been destroyed should
+    raise'''
+    m = Morphology(DATA_DIR / 'simple.swc')
+    s = m.root_sections[0]
+    del m # ~mut.Morphology() called
+    with assert_raises(RuntimeError) as obj:
+        s.children
+
+def test_lifetime_2():
+    '''Attempting to access topological information after a Morphology has been destroyed should
+    raise'''
+    section = _get_section()
+    assert_array_equal(section.points,
+                       np.array([[0., 0., 0.],
+                                 [0., 5., 0.]], dtype=np.float32))
+
+    with assert_raises(RuntimeError) as obj:
+        section.children
+
+def test_lifetime_3():
+    '''Copy a section from a destroyed morphology should work because it does not use any
+    topological information'''
+    section = _get_section()
+
+    # Proof that the morphology has really been destroyed
+    with assert_raises(RuntimeError) as obj:
+        section.children
+
+    morph = Morphology()
+    morph.append_root_section(section)
+    del section
+    assert_equal(len(morph.root_sections), 1)
+    assert_array_equal(morph.root_sections[0].points,
+                       np.array([[0., 0., 0.],
+                                 [0., 5., 0.]], dtype=np.float32))


### PR DESCRIPTION
* when a mut::Morphology is deleted, and it resets the mut::Section::_morphology
  to null.
* added getter to mut::Section to retrieve owning morphology that will
  throw if the above pointer is null
* attempt to fix https://github.com/BlueBrain/MorphIO/issues/161
* This passes all the tests that were added for #234