### PR TITLE
extending std namespace is undefined behavior

### DIFF
--- a/include/morphio/vasc/properties.h
+++ b/include/morphio/vasc/properties.h
@@ -106,7 +106,3 @@ std::vector<Connection::Type>& Properties::get<Connection>() noexcept;
 }  // namespace property
 }  // namespace vasculature
 }  // namespace morphio
-
-namespace std {
-extern template string to_string<morphio::floatType, 3>(const array<morphio::floatType, 3>&);
-}  // namespace std

--- a/include/morphio/vector_types.h
+++ b/include/morphio/vector_types.h
@@ -63,13 +63,3 @@ std::ostream& operator<<(std::ostream& os, const Points& points);
 }  // namespace morphio
 std::ostream& operator<<(std::ostream& os, const morphio::Point& point);
 std::ostream& operator<<(std::ostream& os, const morphio::Points& points);
-
-namespace std {
-template <typename T, size_t N>
-string to_string(const array<T, N>& a) {
-    std::ostringstream oss;
-    std::copy(a.begin(), a.end(), std::ostream_iterator<T>(oss, ", "));
-    return oss.str();
-}
-
-}  // namespace std

--- a/src/mut/mitochondria.cpp
+++ b/src/mut/mitochondria.cpp
@@ -1,7 +1,10 @@
+#include <queue>  // std::queue
+
 #include <morphio/mut/mitochondria.h>
 #include <morphio/mut/writers.h>
-#include <morphio/shared_utils.tpp>
-#include <queue>  // std::queue
+
+
+#include "../shared_utils.hpp"
 
 namespace morphio {
 namespace mut {

--- a/src/mut/morphology.cpp
+++ b/src/mut/morphology.cpp
@@ -9,9 +9,10 @@
 #include <morphio/mut/morphology.h>
 #include <morphio/mut/section.h>
 #include <morphio/mut/writers.h>
-#include <morphio/shared_utils.tpp>
 #include <morphio/soma.h>
 #include <morphio/tools.h>
+
+#include "../shared_utils.hpp"
 
 namespace morphio {
 namespace mut {

--- a/src/mut/soma.cpp
+++ b/src/mut/soma.cpp
@@ -1,10 +1,9 @@
-#include <cmath>
-
 #include <morphio/mut/soma.h>
 #include <morphio/soma.h>
 
 #include <morphio/section.h>
-#include <morphio/shared_utils.tpp>
+
+#include "../shared_utils.hpp"
 
 namespace morphio {
 namespace mut {

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -3,8 +3,9 @@
 
 #include <morphio/errorMessages.h>
 #include <morphio/properties.h>
-#include <morphio/shared_utils.tpp>
 #include <morphio/vector_types.h>
+
+#include "shared_utils.hpp"
 
 
 namespace morphio {
@@ -67,7 +68,7 @@ bool compare(const std::vector<T>& vec1,
         for (unsigned int i = 0; i < vec1.size(); ++i) {
             if (vec1[i] != vec2[i]) {
                 printError(Warning::UNDEFINED,
-                           std::to_string(vec1[i]) + " <--> " + std::to_string(vec2[i]));
+                           valueToString(vec1[i]) + " <--> " + valueToString(vec2[i]));
             }
         }
     }
@@ -121,8 +122,8 @@ bool compare(const morphio::range<T>& vec1,
         if (std::fabs(vec1[i] - vec2[i]) > morphio::epsilon) {
             printError(Warning::UNDEFINED, "Error comparing " + name + ", elements differ:");
             printError(Warning::UNDEFINED,
-                       std::to_string(vec1[i]) + " <--> " + std::to_string(vec2[i]));
-            printError(Warning::UNDEFINED, std::to_string(vec2[i] - vec1[i]));
+                       valueToString(vec1[i]) + " <--> " + valueToString(vec2[i]));
+            printError(Warning::UNDEFINED, valueToString(vec2[i] - vec1[i]));
             return false;
         }
     }
@@ -147,8 +148,8 @@ bool compare(const morphio::range<const morphio::Point>& vec1,
             if (logLevel > LogLevel::ERROR) {
                 printError(Warning::UNDEFINED, "Error comparing " + name + ", elements differ:");
                 printError(Warning::UNDEFINED,
-                           std::to_string(vec1[i]) + " <--> " + std::to_string(vec2[i]));
-                printError(Warning::UNDEFINED, std::to_string(vec2[i] - vec1[i]));
+                           valueToString(vec1[i]) + " <--> " + valueToString(vec2[i]));
+                printError(Warning::UNDEFINED, valueToString(vec2[i] - vec1[i]));
             }
             return false;
         }

--- a/src/shared_utils.hpp
+++ b/src/shared_utils.hpp
@@ -3,10 +3,22 @@
 
 
 namespace morphio {
+
+template <typename T, size_t N>
+std::string valueToString(const std::array<T, N>& a) {
+    std::ostringstream oss;
+    std::copy(a.begin(), a.end(), std::ostream_iterator<T>(oss, ", "));
+    return oss.str();
+}
+template <typename T>
+std::string valueToString(const T a) {
+    return std::to_string(a);
+}
+
 template <typename ContainerDiameters, typename ContainerPoints>
 floatType _somaSurface(const SomaType type,
-                   const ContainerDiameters& diameters,
-                   const ContainerPoints& points) {
+                       const ContainerDiameters& diameters,
+                       const ContainerPoints& points) {
     size_t size = points.size();
     if (size == 0)
         return 0.;
@@ -29,8 +41,7 @@ floatType _somaSurface(const SomaType type,
             floatType r0 = static_cast<morphio::floatType>(diameters[i]) * floatType{0.5};
             floatType r1 = static_cast<morphio::floatType>(diameters[i + 1]) * floatType{0.5};
             floatType h2 = distance(points[i], points[i + 1]);
-            auto s = morphio::PI * (r0 + r1) *
-                     std::sqrt((r0 - r1) * (r0 - r1) + h2 * h2);
+            auto s = morphio::PI * (r0 + r1) * std::sqrt((r0 - r1) * (r0 - r1) + h2 * h2);
             surface += s;
         }
         return surface;

--- a/src/soma.cpp
+++ b/src/soma.cpp
@@ -1,7 +1,8 @@
 #include <morphio/section.h>
-#include <morphio/shared_utils.tpp>
 #include <morphio/soma.h>
 #include <morphio/vector_types.h>
+
+#include "shared_utils.hpp"
 
 namespace morphio {
 Soma::Soma(const std::shared_ptr<Property::Properties>& properties)

--- a/src/vasc/properties.cpp
+++ b/src/vasc/properties.cpp
@@ -3,11 +3,12 @@
 
 #include <morphio/errorMessages.h>
 #include <morphio/properties.h>
-#include <morphio/shared_utils.tpp>
 #include <morphio/vasc/properties.h>
 
+#include "../shared_utils.hpp"
 
 namespace morphio {
+
 namespace vasculature {
 static bool verbose = false;
 namespace property {
@@ -48,10 +49,10 @@ bool compare(const std::vector<T>& vec1,
 
     if (verbose_) {
         printError(Warning::UNDEFINED, "Error comparing " + name + ", elements differ:");
-        for (unsigned int i = 0; i < vec1.size(); ++i) {
+        for (size_t i = 0; i < vec1.size(); ++i) {
             if (vec1[i] != vec2[i]) {
                 printError(Warning::UNDEFINED,
-                           std::to_string(vec1[i]) + " <--> " + std::to_string(vec2[i]));
+                           valueToString(vec1[i]) + " <--> " + valueToString(vec2[i]));
             }
         }
     }
@@ -70,7 +71,7 @@ static bool compare_section_structure(const std::vector<VascSection::Type>& vec1
         return false;
     }
 
-    for (unsigned int i = 1; i < vec1.size(); ++i) {
+    for (size_t i = 1; i < vec1.size(); ++i) {
         if (vec1[i] - vec1[1] != vec2[i] - vec2[1]) {
             if (verbose_) {
                 printError(Warning::UNDEFINED, "Error comparing " + name + ", elements differ:");
@@ -97,12 +98,12 @@ bool compare(const morphio::range<T>& vec1,
         return false;
     }
 
-    for (unsigned int i = 0; i < vec1.size(); ++i) {
+    for (size_t i = 0; i < vec1.size(); ++i) {
         if (std::fabs(vec1[i] - vec2[i]) > morphio::epsilon) {
             printError(Warning::UNDEFINED, "Error comparing " + name + ", elements differ:");
             printError(Warning::UNDEFINED,
-                       std::to_string(vec1[i]) + " <--> " + std::to_string(vec2[i]));
-            printError(Warning::UNDEFINED, std::to_string(vec2[i] - vec1[i]));
+                       valueToString(vec1[i]) + " <--> " + valueToString(vec2[i]));
+            printError(Warning::UNDEFINED, valueToString(vec2[i] - vec1[i]));
             return false;
         }
     }
@@ -122,13 +123,13 @@ bool compare(const morphio::range<const morphio::Point>& vec1,
         return false;
     }
 
-    for (unsigned int i = 0; i < vec1.size(); ++i) {
+    for (size_t i = 0; i < vec1.size(); ++i) {
         if (std::fabs(distance(vec1[i], vec2[i])) > morphio::epsilon) {
             if (verbose_) {
                 printError(Warning::UNDEFINED, "Error comparing " + name + ", elements differ:");
                 printError(Warning::UNDEFINED,
-                           std::to_string(vec1[i]) + " <--> " + std::to_string(vec2[i]));
-                printError(Warning::UNDEFINED, std::to_string(vec2[i] - vec1[i]));
+                           valueToString(vec1[i]) + " <--> " + valueToString(vec2[i]));
+                printError(Warning::UNDEFINED, valueToString(vec2[i] - vec1[i]));
             }
             return false;
         }
@@ -252,7 +253,7 @@ std::ostream& operator<<(std::ostream& os, const VascPointLevel& prop) {
     os << "Point level properties:\n";
     os << "Point diameter"
        << (prop._diameters.size() == prop._points.size() ? " Diameter\n" : "\n");
-    for (unsigned int i = 0; i < prop._points.size(); ++i) {
+    for (size_t i = 0; i < prop._points.size(); ++i) {
         os << dumpPoint(prop._points[i]) << ' ' << prop._diameters[i] << '\n';
     }
     return os;

--- a/src/vector_utils.cpp
+++ b/src/vector_utils.cpp
@@ -1,7 +1,6 @@
 #include <algorithm>  // std::max
 #include <cmath>      // std::sqrt
 #include <numeric>    // std::accumulate
-#include <sstream>    // std::stringstream
 #include <string>     // std::string
 #include <cctype>     // std::tolower
 


### PR DESCRIPTION
* remove the injection of an std::to_string overload - no undefined behavior
* clean up some headers; move shared_utils to internal - shoudn't be
  part of the external interface