### PR TITLE
Change glial cell section types according to new spec

### DIFF
--- a/binds/python/bind_misc.cpp
+++ b/binds/python/bind_misc.cpp
@@ -63,9 +63,10 @@ void bind_misc(py::module& m) {
         .value("custom8", morphio::enums::SectionType::SECTION_CUSTOM_8)
         .value("custom9", morphio::enums::SectionType::SECTION_CUSTOM_9)
         .value("custom10", morphio::enums::SectionType::SECTION_CUSTOM_10)
+        .value("glia_perivascular_process",
+               morphio::enums::SectionType::SECTION_GLIA_PERIVASCULAR_PROCESS)
+        .value("glia_process", morphio::enums::SectionType::SECTION_GLIA_PROCESS)
         .value("all", morphio::enums::SectionType::SECTION_ALL)
-        // .value("glia_process", morphio::enums::SectionType::SECTION_GLIA_PROCESS)
-        // .value("glia_endfoot", morphio::enums::SectionType::SECTION_GLIA_ENDFOOT)
         .export_values();
 
     py::enum_<morphio::enums::VascularSectionType>(m, "VasculatureSectionType")

--- a/include/morphio/enums.h
+++ b/include/morphio/enums.h
@@ -58,8 +58,9 @@ enum SectionType {
     SECTION_AXON = 2,
     SECTION_DENDRITE = 3,         //!< general or basal dendrite (near to soma)
     SECTION_APICAL_DENDRITE = 4,  //!< apical dendrite (far from soma)
-    SECTION_GLIA_PROCESS = 2,     // TODO: nasty overload there
-    SECTION_GLIA_ENDFOOT = 3,
+
+    SECTION_GLIA_PERIVASCULAR_PROCESS = 2,
+    SECTION_GLIA_PROCESS = 3,  // TODO: nasty overload there
 
     // unnamed custom section types
     SECTION_CUSTOM_5 = 5,

--- a/tests/test_4_immut.py
+++ b/tests/test_4_immut.py
@@ -147,7 +147,7 @@ def test_glia():
     g = GlialCell(os.path.join(_path, 'astrocyte.h5'))
     assert g.cell_family == CellFamily.GLIA
     assert g.sections[100].type == SectionType.glia_perivascular_process
-    assert g,sections[1000].type == SectionType.glia_process
+    assert g.sections[1000].type == SectionType.glia_process
 
     g = GlialCell(Path(_path, 'astrocyte.h5'))
     assert g.cell_family == CellFamily.GLIA

--- a/tests/test_4_immut.py
+++ b/tests/test_4_immut.py
@@ -3,10 +3,10 @@ from collections import OrderedDict
 
 import numpy as np
 import pytest
-from numpy.testing import assert_array_almost_equal, assert_array_equal
+from numpy.testing import assert_array_almost_equal, assert_array_equal, assert_equal
 from pathlib import Path
 
-from morphio import IterType, Morphology, GlialCell, CellFamily, RawDataError
+from morphio import SectionType, IterType, Morphology, GlialCell, CellFamily, RawDataError
 
 _path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
 
@@ -139,6 +139,11 @@ def test_more_iter():
 
 
 def test_glia():
+
+    # check the glia section types
+    assert_equal(int(SectionType.glia_perivascular_process), 2)
+    assert_equal(int(SectionType.glia_process), 3)
+
     g = GlialCell(os.path.join(_path, 'astrocyte.h5'))
     assert g.cell_family == CellFamily.GLIA
 

--- a/tests/test_4_immut.py
+++ b/tests/test_4_immut.py
@@ -146,6 +146,8 @@ def test_glia():
 
     g = GlialCell(os.path.join(_path, 'astrocyte.h5'))
     assert g.cell_family == CellFamily.GLIA
+    assert g.sections[100].type == SectionType.glia_perivascular_process
+    assert g,sections[1000].type == SectionType.glia_process
 
     g = GlialCell(Path(_path, 'astrocyte.h5'))
     assert g.cell_family == CellFamily.GLIA

--- a/tests/test_immutable_morphology.cpp
+++ b/tests/test_immutable_morphology.cpp
@@ -294,6 +294,23 @@ TEST_CASE("glia", "[immutableMorphology]") {
     morphio::GlialCell glial = morphio::GlialCell("data/astrocyte.h5");
     REQUIRE(glial.cellFamily() == morphio::CellFamily::GLIA);
 
+    auto section_types = glial.sectionTypes();
+
+    size_t count_processes = 0;
+    size_t count_perivascular_processes = 0;
+
+    for (const auto type : section_types) {
+        if (type == morphio::SECTION_GLIA_PERIVASCULAR_PROCESS)
+            ++count_perivascular_processes;
+        else if (type == morphio::SECTION_GLIA_PROCESS)
+            ++count_processes;
+        else
+            REQUIRE(false);
+    }
+
+    REQUIRE(count_perivascular_processes == 452);
+    REQUIRE(count_processes == 863);
+
     CHECK_THROWS_AS(morphio::GlialCell("data/simple.swc"), morphio::RawDataError);
     CHECK_THROWS_AS(morphio::GlialCell("data/h5/v1/simple.h5"), morphio::RawDataError);
 }


### PR DESCRIPTION
The glial section types are changed to reflect the types that are outputted by the ngv building and synthesis. The endfoot process has also been renamed to perivascular to avoid name overlapping with the endfoot as a gliovascular connection.

Before:
```
  2 : glia process
  3 : glia endfoot
```
After:
```
  2 : glia perivascular process
  3 : glia process
```
See updated spec here:
https://bbpteam.epfl.ch/documentation/projects/Morphology%20Documentation/latest/h5v1.html 