### PR TITLE
Warn about disconnected neurite only when there is a soma.

### DIFF
--- a/src/readers/morphologySWC.cpp
+++ b/src/readers/morphologySWC.cpp
@@ -132,8 +132,14 @@ class SWCBuilder
         if (somata.size() > 1)
             throw morphio::SomaError(err.ERROR_MULTIPLE_SOMATA(somata));
 
-        if (somata.empty())
+        if (somata.empty()) {
             printError(Warning::NO_SOMA_FOUND, err.WARNING_NO_SOMA_FOUND());
+        } else {
+            for (const auto& sample_pair : samples) {
+                const auto& sample = sample_pair.second;
+                warnIfDisconnectedNeurite(sample);
+            }
+        }
     }
 
     void raiseIfNoParent(const Sample& sample) {
@@ -195,7 +201,6 @@ class SWCBuilder
         raiseIfBrokenSoma(sample);
         raiseIfNoParent(sample);
         warnIfZeroDiameter(sample);
-        warnIfDisconnectedNeurite(sample);
     }
 
     void _checkNeuroMorphoSoma(const Sample& root, const std::vector<Sample>& _children) {

--- a/tests/test_1_swc.py
+++ b/tests/test_1_swc.py
@@ -486,3 +486,14 @@ def test_zero_diameter():
 def test_version():
     assert_array_equal(Morphology(os.path.join(_path, 'simple.swc')).version,
                        ('swc', 1, 0))
+
+
+def test_no_soma():
+    swc_content = '''1 2 0 0 0 3.0 -1
+                     2 2 0 0 0 3.0  1
+                     3 2 0 0 0 3.0  2'''
+    with captured_output() as (_, err):
+        with ostream_redirect(stdout=True, stderr=True), tmp_swc_file(swc_content) as tmp_file:
+            n = Morphology(tmp_file.name)
+            assert ('{}:0:warning\nWarning: no soma found in file'.format(tmp_file.name) ==
+                    strip_color_codes(err.getvalue().strip()))


### PR DESCRIPTION
It is legal to have disconnected neurite when there is no soma. Warn only about missing soma in that case.