### PR TITLE
don't compile c++ tests when creating python package

### DIFF
--- a/ci/python_test.sh
+++ b/ci/python_test.sh
@@ -4,22 +4,39 @@ set -euxo pipefail
 
 VENV=env
 
-if [[ "$OSTYPE" != "msys" ]]; then
-    rm -rf "$VENV"
-    python3 -mvenv "$VENV"
+function create_venv()
+{
+    if [[ "$OSTYPE" != "msys" ]]; then
+        rm -rf "$VENV"
+        python3 -mvenv "$VENV"
 
-    set +u  # ignore errors in virtualenv's activate
-    source "$VENV/bin/activate"
-    set -u
+        set +u  # ignore errors in virtualenv's activate
+        source "$VENV/bin/activate"
+        set -u
 
-    which pip
+        which pip
 
-    pip install --upgrade pip setuptools
-fi
+        pip install --upgrade pip setuptools wheel
+    fi
+}
 
-pip install .
+# in tree install
+create_venv
+# https://github.com/pypa/pip/issues/7555
+pip install --use-feature=in-tree-build .
 pip install -r tests/requirement_tests.txt
 
 CURRENT=$(pwd)
-cd ..
-pytest ${CURRENT}/tests
+(cd .. && pytest ${CURRENT}/tests)
+deactivate
+
+# sdist install
+DIST_DIR="$VENV/dist"
+mkdir -p "$DIST_DIR"
+create_venv
+python3 setup.py sdist --dist-dir "$DIST_DIR"
+pip install "$DIST_DIR"/MorphIO*.tar.gz
+pip install -r tests/requirement_tests.txt
+
+CURRENT=$(pwd)
+(cd .. && pytest ${CURRENT}/tests)

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ class CMakeBuild(build_ext):
             os.path.dirname(self.get_ext_fullpath(ext.name)))
         cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
                       '-DMORPHIO_VERSION_STRING=' + self.distribution.get_version(),
+                      '-DMORPHIO_TESTS=OFF',
                       '-DPYTHON_EXECUTABLE=' + sys.executable,
                       '-DHIGHFIVE_EXAMPLES=OFF',
                       '-DHIGHFIVE_UNIT_TESTS=OFF',


### PR DESCRIPTION
* thus we don't need a c++17 compiler