### PR TITLE
Remove explicit template class instantiation

### DIFF
--- a/include/morphio/section.h
+++ b/include/morphio/section.h
@@ -91,9 +91,6 @@ class Section: public SectionBase<Section>
         : SectionBase(id_, properties) {}
 };
 
-// explicit instanciation
-template class SectionBase<Section>;
-
 }  // namespace morphio
 
 std::ostream& operator<<(std::ostream& os, const morphio::Section& section);


### PR DESCRIPTION
Fixes an error on armv7hl like this:

```
  FAILED: binds/python/_morphio.cpython-310-arm-linux-gnueabihf.so
  : && /usr/bin/g++ -fPIC -O2 -flto=auto -ffat-lto-objects -fexceptions -g
      -grecord-gcc-switches -pipe -Wall -Werror=format-security
      -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS
      -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong
      -march=armv7-a -mfpu=vfpv3-d16 -mtune=generic-armv7-a -mabi=aapcs-linux
      -mfloat-abi=hard  -Wl,-z,relro -Wl,--as-needed  -Wl,-z,now
      -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -shared  -o
      binds/python/_morphio.cpython-310-arm-linux-gnueabihf.so
      binds/python/CMakeFiles/_morphio.dir/morphio.cpp.o
      binds/python/CMakeFiles/_morphio.dir/bind_immutable.cpp.o
      binds/python/CMakeFiles/_morphio.dir/bindings_utils.cpp.o
      binds/python/CMakeFiles/_morphio.dir/bind_misc.cpp.o
      binds/python/CMakeFiles/_morphio.dir/bind_mutable.cpp.o
      binds/python/CMakeFiles/_morphio.dir/bind_vasculature.cpp.o  -flto
      src/libmorphio_static.a  -lhdf5 && :
  /usr/bin/ld: binds/python/CMakeFiles/_morphio.dir/bind_mutable.cpp.o (symbol
      from plugin): in function `bind_mutable_module(pybind11::module&)':
  (.text+0x0): multiple definition of `typeinfo name for
      morphio::SectionBase<morphio::Section>';
      binds/python/CMakeFiles/_morphio.dir/bind_immutable.cpp.o (symbol from
      plugin):(.text+0x0): first defined here
  /usr/bin/ld: binds/python/CMakeFiles/_morphio.dir/bind_mutable.cpp.o (symbol
      from plugin): in function `bind_mutable_module(pybind11::module&)':
  (.text+0x0): multiple definition of `typeinfo for
      morphio::SectionBase<morphio::Section>';
      binds/python/CMakeFiles/_morphio.dir/bind_immutable.cpp.o (symbol from
      plugin):(.text+0x0): first defined here
```

This indicates an identical explicit template instantiation appears in more than one translation unit, which violates the C++ standard. Since the instantiation is in a header, this occurs whenever the header is included in more than one translation unit. GCC tends to produce an error about this on 32-bit ARM but not on other common architectures. See also https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=608029.