### PR TITLE
Remove unused python mock dependency

### DIFF
--- a/tests/requirement_tests.txt
+++ b/tests/requirement_tests.txt
@@ -1,5 +1,4 @@
 h5py>=2.9.0
-mock>=2.0.0
 pytest>=6.0
 numpy>=1.14.2
 requests>=2.25.1


### PR DESCRIPTION
While `mock` is in `tests/requirements_tests.txt`, nothing actually uses it. (Starting with Python 3.3, it is in the standard library as `unittest.mock` anyway.)