### PR TITLE
Work around conda cmake finding HDF5 issues by building docs with libhdf5-dev already installed

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,5 +9,13 @@ submodules:
   include: all
   recursive: true
 
+# it appears that the conda `cmake` finds `conda` installed packages
+# fine, but if cmake is installed through `pyproject.toml`, that CMake
+# doesn't find HDF5, if the hdf5 headers are available by the system, then
+# it works
+build:
+  apt_packages:
+    - libhdf5-dev
+
 conda:
   environment: doc/environment.yml

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -3,7 +3,6 @@ channels:
   - defaults
 dependencies:
   - python=3.6
-  - hdf5
-  - cmake
+  - pip
   - pip:
     - ..[docs]


### PR DESCRIPTION
* switching to pyproject.toml broke the read the docs build in conda
* it appears that the conda `cmake` finds `conda` installed packages
  fine, but if cmake is installed through `pyproject.toml`, that CMake
  doesn't find HDF5
* I don't want to change pyproject.toml building - it works in windows