### PR TITLE
dependencies: allow to use an external pybind11.

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -14,3 +14,11 @@ target_include_directories(gsl-lite SYSTEM INTERFACE)
 
 add_library(lexertl INTERFACE)
 target_include_directories(lexertl SYSTEM INTERFACE lexertl14/include)
+
+if(BUILD_BINDINGS)
+  if (NOT EXTERNAL_PYBIND11)
+    add_subdirectory(pybind11)
+    target_include_directories(pybind11 SYSTEM INTERFACE
+      pybind11)
+  endif()
+endif()

--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -14,11 +14,3 @@ target_include_directories(gsl-lite SYSTEM INTERFACE)
 
 add_library(lexertl INTERFACE)
 target_include_directories(lexertl SYSTEM INTERFACE lexertl14/include)
-
-if(BUILD_BINDINGS)
-  if (NOT EXTERNAL_PYBIND11)
-    add_subdirectory(pybind11)
-    target_include_directories(pybind11 SYSTEM INTERFACE
-      pybind11)
-  endif()
-endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,8 @@ set(CMAKE_VERBOSE_MAKEFILE ON)
 
 option(BUILD_BINDINGS "Build the python bindings" ON)
 option(MorphIO_CXX_WARNINGS "Compile C++ with warnings" ON)
-option(EXTERNAL_HIGHFIVE "Use HighFive from external source" ON)
-option(EXTERNAL_PYBIND11 "Use pybind11 from external source" ON)
+option(EXTERNAL_HIGHFIVE "Use HighFive from external source" OFF)
+option(EXTERNAL_PYBIND11 "Use pybind11 from external source" OFF)
 option(MORPHIO_TESTS "Build tests" ON)
 option(MORPHIO_USE_DOUBLE "Use doubles instead of floats" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,8 @@ set(CMAKE_VERBOSE_MAKEFILE ON)
 
 option(BUILD_BINDINGS "Build the python bindings" ON)
 option(MorphIO_CXX_WARNINGS "Compile C++ with warnings" ON)
-option(EXTERNAL_HIGHFIVE "Use HighFive from external source" OFF)
+option(EXTERNAL_HIGHFIVE "Use HighFive from external source" ON)
+option(EXTERNAL_PYBIND11 "Use pybind11 from external source" ON)
 option(MORPHIO_TESTS "Build tests" ON)
 option(MORPHIO_USE_DOUBLE "Use doubles instead of floats" OFF)
 
@@ -32,6 +33,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if (EXTERNAL_HIGHFIVE)
   find_package(HighFive REQUIRED)
+endif()
+if (EXTERNAL_PYBIND11)
+  find_package(pybind11 REQUIRED CONFIG)
 endif()
 set(MORPHIO_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/include/)
 

--- a/binds/python/CMakeLists.txt
+++ b/binds/python/CMakeLists.txt
@@ -1,4 +1,6 @@
-add_subdirectory(pybind11 EXCLUDE_FROM_ALL)
+if (NOT EXTERNAL_PYBIND11)
+    add_subdirectory(pybind11 EXCLUDE_FROM_ALL)
+endif()
 
 pybind11_add_module(_morphio SYSTEM
     morphio.cpp


### PR DESCRIPTION
Fixes #337.
