### PR TITLE
ci: trigger a build of downstream morpho-kit

### DIFF
--- a/.github/workflows/downstream-check.yml
+++ b/.github/workflows/downstream-check.yml
@@ -1,7 +1,7 @@
 name: Check downstream builds
-# on:
-#   push:
-#     branches: [master]
+on:
+  push:
+    branches: [master, trigger-downstream-morphokit]
 
 jobs:
   build:

--- a/.github/workflows/downstream-check.yml
+++ b/.github/workflows/downstream-check.yml
@@ -9,8 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger job
-        uses: appleboy/gitlab-ci-action@master
-        with:
-          host: "https://bbpgitlab.epfl.ch"
-          token: ${{ secrets.GITLAB_MORPHOKIT_TRIGGER_TOKEN }}
-          project_id: 903
+        run: |
+          hostname
+          curl --request POST \
+              --form token=${{ secrets.GITLAB_MORPHOKIT_TRIGGER_TOKEN }} \
+              --form ref=main \
+              "https://bbpgitlab.epfl.ch/api/v4/projects/903/trigger/pipeline"

--- a/.github/workflows/downstream-check.yml
+++ b/.github/workflows/downstream-check.yml
@@ -1,0 +1,16 @@
+name: Check downstream builds
+# on:
+#   push:
+#     branches: [master]
+
+jobs:
+  build:
+    name: Trigger morpho-kit build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger job
+        uses: appleboy/gitlab-ci-action@master
+        with:
+          host: "https://bbpgitlab.epfl.ch"
+          token: ${{ secrets.GITLAB_MORPHOKIT_TRIGGER_TOKEN }}
+          project_id: 903


### PR DESCRIPTION
Should fullfil the requirements outlined in NSETM-915 by triggering a
build of morpho-kit whenever a push to the main branch of MorphIO
occurs.

Needs to have the corresponding token set, still.
