### PR TITLE
Exclude musllinux wheels building

### DIFF
--- a/.github/workflows/publish-sdist-wheels.yml
+++ b/.github/workflows/publish-sdist-wheels.yml
@@ -4,7 +4,7 @@ on: [pull_request, push]
 env:
   CIBW_BUILD_VERBOSITY: 3
   CIBW_BUILD: 'cp3?-*'
-  CIBW_SKIP: 'cp35-* cp36-* *-manylinux_i686 *-win32'
+  CIBW_SKIP: 'cp35-* cp36-* *-manylinux_i686 *-musllinux_* *-win32'
   CIBW_BEFORE_TEST: pip install -r {project}/tests/requirement_tests.txt
   CIBW_TEST_COMMAND: pytest -s -v {project}/tests
 


### PR DESCRIPTION
musslinux wheels support was added in `cibuildwheel-v2.2.0`, which is enabled by default.

`*-musllinux_*` was added to `CIBW_SKIP` to skip them.

see unintended inclusion of the new wheels here: https://github.com/BlueBrain/MorphIO/runs/4065775082?check_suite_focus=true#step:5:2590 