### PR TITLE
Check for supported python versions

### DIFF
--- a/.github/workflows/check-sdist.yml
+++ b/.github/workflows/check-sdist.yml
@@ -14,10 +14,10 @@ jobs:
         with:
           submodules: 'true'
 
-      - name: Set up Python 3.6
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.8
 
       - name: Build a source tarball
         run:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-equires = ["setuptools>=24.2.0", "wheel", "cmake", "ninja"]
+requires = ["setuptools>=24.2.0", "wheel", "cmake", "ninja"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "cmake", "ninja"]
+equires = ["setuptools>=24.2.0", "wheel", "cmake", "ninja"]

--- a/setup.py
+++ b/setup.py
@@ -97,5 +97,5 @@ setup(
     setup_requires=[
         'setuptools_scm',
     ],
-    python_requires=">=3.7"
+    python_requires=">=3.7",
 )

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,10 @@ from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 
 
+if sys.version_info[:2] < (3, 7):
+    raise RuntimeError("Python version >= 3.7 required.")
+
+
 class CMakeExtension(Extension):
     def __init__(self, name, sourcedir=''):
         Extension.__init__(self, name, sources=[])

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,6 @@ from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 
 
-if sys.version_info[:2] < (3, 7):
-    raise RuntimeError("Python version >= 3.7 required.")
-
-
 class CMakeExtension(Extension):
     def __init__(self, name, sourcedir=''):
         Extension.__init__(self, name, sources=[])
@@ -100,5 +96,6 @@ setup(
     use_scm_version=True,
     setup_requires=[
         'setuptools_scm',
-        ],
+    ],
+    python_requires=">=3.7"
 )


### PR DESCRIPTION
A check is added in `setup.py` which results in a `RuntimeError` if morphio is pip installed in a python environment for which there are no wheels available. 