### PR TITLE
fix operator<< instances

### DIFF
--- a/binds/python/bind_vasculature.cpp
+++ b/binds/python/bind_vasculature.cpp
@@ -99,6 +99,13 @@ void bind_vasculature(py::module& m) {
 
 
     py::class_<morphio::vasculature::Section>(m, "Section")
+        .def("__str__",
+             [](const morphio::vasculature::Section& section) {
+                 std::stringstream ss;
+                 ss << section;
+                 return ss.str();
+             })
+
         // Topology-related member functions
         .def_property_readonly("predecessors",
                                &morphio::vasculature::Section::predecessors,

--- a/include/morphio/mut/morphology.h
+++ b/include/morphio/mut/morphology.h
@@ -1,10 +1,7 @@
 #pragma once
 
 #include <cstdint>
-#include <iomanip>
-#include <iostream>
 #include <memory>
-#include <ostream>
 #include <unordered_map>
 
 #include <functional>

--- a/include/morphio/section.h
+++ b/include/morphio/section.h
@@ -101,4 +101,3 @@ class Section: public SectionBase<Section>
 }  // namespace morphio
 
 std::ostream& operator<<(std::ostream& os, const morphio::Section& section);
-std::ostream& operator<<(std::ostream& os, const morphio::range<const morphio::Point>& points);

--- a/include/morphio/section_base.h
+++ b/include/morphio/section_base.h
@@ -7,6 +7,7 @@
 #include <morphio/morphology.h>
 #include <morphio/properties.h>
 #include <morphio/types.h>
+#include <morphio/vector_types.h>
 
 namespace morphio {
 /**
@@ -81,8 +82,5 @@ inline uint32_t SectionBase<T>::id() const noexcept {
 }
 
 }  // namespace morphio
-
-std::ostream& operator<<(std::ostream& os, const morphio::Section& section);
-std::ostream& operator<<(std::ostream& os, const morphio::range<const morphio::Point>& points);
 
 #include "section_base.tpp"

--- a/include/morphio/types.h
+++ b/include/morphio/types.h
@@ -4,7 +4,6 @@
 #include <string>  // std::string
 #include <vector>  // std::vector
 
-#include <gsl/gsl>
 #include <morphio/enums.h>
 #include <morphio/exceptions.h>
 #include <morphio/vector_types.h>
@@ -57,8 +56,5 @@ using SectionRange = std::pair<size_t, size_t>;
 
 // A tuple (file format (std::string), major version, minor version)
 using MorphologyVersion = std::tuple<std::string, uint32_t, uint32_t>;
-
-template <typename T>
-using range = gsl::span<T>;
 
 }  // namespace morphio

--- a/include/morphio/vasc/section.h
+++ b/include/morphio/vasc/section.h
@@ -1,4 +1,6 @@
 #pragma once
+
+#include <iosfwd>  // std::ostream
 #include <memory>  // std::shared_ptr
 #include <vector>  // std::vector
 
@@ -83,4 +85,3 @@ class Section
 }  // namespace morphio
 
 std::ostream& operator<<(std::ostream& os, const morphio::vasculature::Section& section);
-std::ostream& operator<<(std::ostream& os, const morphio::range<const morphio::Point>& points);

--- a/include/morphio/vector_types.h
+++ b/include/morphio/vector_types.h
@@ -2,12 +2,17 @@
 
 #include <array>
 #include <cmath>
-#include <iostream>
-#include <sstream>
+#include <iosfwd>  // std::ostream
 #include <string>  // std::string
 #include <vector>
 
+#include <gsl/gsl>
+
 namespace morphio {
+
+template <typename T>
+using range = gsl::span<T>;
+
 #ifdef MORPHIO_USE_DOUBLE
 using floatType = double;
 constexpr floatType epsilon = 1e-6;
@@ -51,8 +56,8 @@ extern template Point centerOfGravity(const Points&);
 extern template floatType maxDistanceToCenterOfGravity(const Points&);
 
 std::string dumpPoint(const Point& point);
-std::string dumpPoints(const Points& point);
-
+std::string dumpPoints(const Points& points);
+std::string dumpPoints(const morphio::range<const morphio::Point>& points);
 
 char my_tolower(char ch);
 
@@ -61,9 +66,8 @@ char my_tolower(char ch);
 **/
 floatType distance(const Point& left, const Point& right);
 
-std::ostream& operator<<(std::ostream& os, const morphio::Point& point);
-std::ostream& operator<<(std::ostream& os, const Points& points);
-
 }  // namespace morphio
+
 std::ostream& operator<<(std::ostream& os, const morphio::Point& point);
 std::ostream& operator<<(std::ostream& os, const morphio::Points& points);
+std::ostream& operator<<(std::ostream& os, const morphio::range<const morphio::Point>& points);

--- a/src/mut/section.cpp
+++ b/src/mut/section.cpp
@@ -5,6 +5,7 @@
 #include <morphio/mut/morphology.h>
 #include <morphio/mut/section.h>
 #include <morphio/tools.h>
+#include <morphio/vector_types.h>
 
 namespace morphio {
 namespace mut {
@@ -111,6 +112,7 @@ upstream_iterator Section::upstream_end() const {
     return upstream_iterator();
 }
 
+/*
 static std::ostream& operator<<(std::ostream& os, const Section& section) {
     ::operator<<(os, section);
     return os;
@@ -120,6 +122,7 @@ std::ostream& operator<<(std::ostream& os, const std::shared_ptr<Section>& secti
     os << *sectionPtr;
     return os;
 }
+*/
 
 std::shared_ptr<Section> Section::appendSection(std::shared_ptr<Section> original_section,
                                                 bool recursive) {
@@ -228,12 +231,12 @@ std::shared_ptr<Section> Section::appendSection(const Property::PointLevel& poin
 }  // end namespace morphio
 
 std::ostream& operator<<(std::ostream& os, const morphio::mut::Section& section) {
-    auto points = section.points();
+    const auto& points = section.points();
     if (points.empty()) {
         os << "Section(id=" << section.id() << ", points=[])";
     } else {
-        os << "Section(id=" << section.id() << ", points=[(" << points[0] << "),..., (";
-        os << points[points.size() - 1] << ")])";
+        os << "Section(id=" << section.id() << ", points=[(" << points[0] << "),..., ("
+           << points[points.size() - 1] << ")])";
     }
 
     return os;

--- a/src/mut/writers.cpp
+++ b/src/mut/writers.cpp
@@ -1,5 +1,6 @@
 #include <cassert>
 #include <fstream>
+#include <iomanip>  // std::fixed, std::setw
 
 #include <morphio/errorMessages.h>
 #include <morphio/mut/mitochondria.h>

--- a/src/section.cpp
+++ b/src/section.cpp
@@ -63,16 +63,8 @@ std::ostream& operator<<(std::ostream& os, const morphio::Section& section) {
     if (points.empty()) {
         os << "Section(id=" << section.id() << ", points=[])";
     } else {
-        os << "Section(id=" << section.id() << ", points=[(" << points[0] << "),..., (";
-        os << points[points.size() - 1] << ")])";
-    }
-    return os;
-}
-
-// operator<< must be defined in the global namespace to be usable there
-std::ostream& operator<<(std::ostream& os, const morphio::range<const morphio::Point>& points) {
-    for (const auto& point : points) {
-        os << point[0] << ' ' << point[1] << ' ' << point[2] << '\n';
+        os << "Section(id=" << section.id() << ", points=[(" << points[0] << "),..., ("
+           << points[points.size() - 1] << ")])";
     }
     return os;
 }

--- a/src/vasc/section.cpp
+++ b/src/vasc/section.cpp
@@ -1,3 +1,5 @@
+#include <iostream>
+
 #include <morphio/vasc/section.h>
 
 namespace morphio {
@@ -19,9 +21,11 @@ Section::Section(const uint32_t id_, const std::shared_ptr<property::Properties>
                                                    : sections[id_ + 1];
     _range = std::make_pair(start, end_);
 
-    if (_range.second <= _range.first)
+    if (_range.second <= _range.first) {
+        // TODO: shouldn't print to std::cerr
         std::cerr << "Dereferencing broken properties section " << _id
                   << "\nSection range: " << _range.first << " -> " << _range.second << '\n';
+    }
 }
 
 Section& Section::operator=(const Section& section) {
@@ -122,3 +126,14 @@ graph_iterator Section::end() const {
 }
 }  // namespace vasculature
 }  // namespace morphio
+
+std::ostream& operator<<(std::ostream& os, const morphio::vasculature::Section& section) {
+    const auto& points = section.points();
+    if (points.empty()) {
+        os << "Section(id=" << section.id() << ", points=[])";
+    } else {
+        os << "Section(id=" << section.id() << ", points=[(" << points[0] << "),..., ("
+           << points[points.size() - 1] << ")])";
+    }
+    return os;
+}

--- a/src/vector_utils.cpp
+++ b/src/vector_utils.cpp
@@ -1,8 +1,9 @@
 #include <algorithm>  // std::max
+#include <cctype>     // std::tolower
 #include <cmath>      // std::sqrt
 #include <numeric>    // std::accumulate
+#include <sstream>    // ostringstream
 #include <string>     // std::string
-#include <cctype>     // std::tolower
 
 #include <morphio/types.h>
 
@@ -87,6 +88,14 @@ std::string dumpPoints(const Points& points) {
     return oss.str();
 }
 
+std::string dumpPoints(const morphio::range<const morphio::Point>& points) {
+    std::ostringstream oss;
+    for (const auto& point : points) {
+        oss << dumpPoint(point) << '\n';
+    }
+    return oss.str();
+}
+
 template <typename T>
 Point centerOfGravity(const T& points) {
     Point::value_type x = 0, y = 0, z = 0;
@@ -107,7 +116,7 @@ floatType maxDistanceToCenterOfGravity(const T& points) {
     return std::accumulate(std::begin(points),
                            std::end(points),
                            floatType{0},
-                           [&](morphio::floatType a, const Point& b) {
+                           [&](floatType a, const Point& b) {
                                return std::max(a, distance(c, b));
                            });
 }
@@ -122,40 +131,36 @@ Point operator*(const Point& from, T factor) {
     return ret;
 }
 template Point operator*<int>(const Point& from, int factor);
-template Point operator*<morphio::floatType>(const Point& from, floatType factor);
+template Point operator*<floatType>(const Point& from, floatType factor);
 
 template <typename T>
 Point operator*(T factor, const Point& from) {
     return from * factor;
 }
 template Point operator*<int>(int factor, const Point& from);
-template Point operator*<morphio::floatType>(morphio::floatType factor, const Point& from);
+template Point operator*<floatType>(floatType factor, const Point& from);
 
 template <typename T>
 Point operator/(const Point& from, T factor) {
-    return from * (1 / static_cast<morphio::floatType>(factor));
+    return from * (1 / static_cast<floatType>(factor));
 }
 template Point operator/(const Point& from, int factor);
 template Point operator/(const Point& from, floatType factor);
-
-std::ostream& operator<<(std::ostream& os, const Points& points) {
-    return os << morphio::dumpPoints(points);
-}
-
-std::ostream& operator<<(std::ostream& os, const morphio::Point& point) {
-    return os << morphio::dumpPoint(point);
-}
 
 // Like std::tolower but accepts char
 char my_tolower(char ch) {
     return static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
 }
-
 }  // namespace morphio
+
+std::ostream& operator<<(std::ostream& os, const morphio::Point& point) {
+    return os << morphio::dumpPoint(point);
+}
 
 std::ostream& operator<<(std::ostream& os, const morphio::Points& points) {
     return os << morphio::dumpPoints(points);
 }
-std::ostream& operator<<(std::ostream& os, const morphio::Point& point) {
-    return os << morphio::dumpPoint(point);
+
+std::ostream& operator<<(std::ostream& os, const morphio::range<const morphio::Point>& points) {
+    return os << morphio::dumpPoints(points);
 }

--- a/tests/test_10_vasculature.py
+++ b/tests/test_10_vasculature.py
@@ -139,3 +139,8 @@ def test_iterators_vasculature():
 def test_from_pathlib():
     vasc = vasculature.Vasculature(Path(_path, "h5/vasculature1.h5"))
     assert len(vasc.sections) == 3080
+
+def test_section___str__():
+    morphology = vasculature.Vasculature(os.path.join(_path, "h5/vasculature1.h5"))
+    assert (str(morphology.section(0)) ==
+                 'Section(id=0, points=[(1265.47 335.424 1869.19),..., (1274 336.7 1876)])')


### PR DESCRIPTION
* missing implementation for morphio::vasculature::Section
* multiple declarations of  morphio::Section
* removed unnecessary `morphio::` in a number of places
* include cleanup