### PR TITLE
Update readthedocs python to 3.9

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -27,3 +27,5 @@ python:
   install:
     - method: pip
       path: .
+      extra_requirements:
+        - docs

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,7 +21,7 @@ build:
     python: "3.9"
 
 sphinx:
-  configuration: docs/source/conf.py
+  configuration: doc/source/conf.py
 
 python:
   install:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,7 +17,8 @@ build:
   os: "ubuntu-20.04"
   apt_packages:
     - libhdf5-dev
-  tools: "mambaforge-4.10"
+  tools:
+    python: "mambaforge-4.10"
 
 conda:
   environment: doc/environment.yml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,11 +20,10 @@ build:
   tools:
     python: "3.9"
 
-python:
-  install:
-    - method: pip
-    - path: .
-
 sphinx:
   configuration: docs/source/conf.py
 
+python:
+  install:
+    - method: pip
+      path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,8 +14,10 @@ submodules:
 # doesn't find HDF5, if the hdf5 headers are available by the system, then
 # it works
 build:
+  os: "ubuntu-20.04"
   apt_packages:
     - libhdf5-dev
+  tools: "mambaforge-4.10"
 
 conda:
   environment: doc/environment.yml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,7 +18,13 @@ build:
   apt_packages:
     - libhdf5-dev
   tools:
-    python: "mambaforge-4.10"
+    python: "3.9"
 
-conda:
-  environment: doc/environment.yml
+python:
+  install:
+    - method: pip
+    - path: .
+
+sphinx:
+  configuration: docs/source/conf.py
+

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,7 +18,7 @@ build:
   apt_packages:
     - libhdf5-dev
   tools:
-    python: "3.9"
+    python: "3.6"
 
 sphinx:
   configuration: doc/source/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,7 +18,7 @@ build:
   apt_packages:
     - libhdf5-dev
   tools:
-    python: "3.6"
+    python: "3.9"
 
 sphinx:
   configuration: doc/source/conf.py

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -1,8 +1,0 @@
-name: morphio
-channels:
-  - defaults
-dependencies:
-  - python=3.6
-  - pip
-  - pip:
-    - ..[docs]

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -2,7 +2,7 @@ name: morphio
 channels:
   - defaults
 dependencies:
-  - python=3.8
+  - python=3.6
   - pip
   - pip:
     - ..[docs]

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -2,7 +2,7 @@ name: morphio
 channels:
   - defaults
 dependencies:
-  - python=3.6
+  - python=3.8
   - pip
   - pip:
     - ..[docs]

--- a/setup.py
+++ b/setup.py
@@ -98,4 +98,7 @@ setup(
         'setuptools_scm',
     ],
     python_requires=">=3.7",
+    extras_require={
+        'docs': ['sphinx-bluebrain-theme>=0.2.5']
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -97,5 +97,4 @@ setup(
     setup_requires=[
         'setuptools_scm',
     ],
-    python_requires=">=3.7",
 )

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,4 @@ setup(
         'setuptools_scm',
     ],
     python_requires=">=3.7",
-    extras_require={
-        'docs': ['sphinx-bluebrain-theme>=0.2.5']
-    }
 )

--- a/setup.py
+++ b/setup.py
@@ -97,4 +97,5 @@ setup(
     setup_requires=[
         'setuptools_scm',
     ],
+    python_requires=">=3.7",
 )


### PR DESCRIPTION
Dropping the wheels for python3.6 without changing the python version in the docs environment resulted into not having wheels available and therefore trying to compile it and exceeding the max available memory.

Updating the python version results in using the wheels and therefore building the documentation without an issue:
https://readthedocs.org/projects/morphio/builds/15565753/