### PR TITLE
Fix windows-2022 wheels & MANIFEST.in warnings

### DIFF
--- a/.github/workflows/publish-sdist-wheels.yml
+++ b/.github/workflows/publish-sdist-wheels.yml
@@ -66,7 +66,7 @@ jobs:
           C:\windows\system32\tar.exe xf hdf5-1.12.0-Std-win10_64-vs16.zip
           start /wait msiexec /a "%cd%\hdf\HDF5-1.12.0-win64.msi" /qn TARGETDIR="c:\hdf5\"
 
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat" -vcvars_ver=14.0
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat" -vcvars_ver=14.2
 
           set HDF5_DIR=C:\hdf5\HDF_Group\HDF5\1.12.0\cmake
 

--- a/.github/workflows/publish-sdist-wheels.yml
+++ b/.github/workflows/publish-sdist-wheels.yml
@@ -66,7 +66,7 @@ jobs:
           C:\windows\system32\tar.exe xf hdf5-1.12.0-Std-win10_64-vs16.zip
           start /wait msiexec /a "%cd%\hdf\HDF5-1.12.0-win64.msi" /qn TARGETDIR="c:\hdf5\"
 
-          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat" -vcvars_ver=14.0
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat" -vcvars_ver=14.0
 
           set HDF5_DIR=C:\hdf5\HDF_Group\HDF5\1.12.0\cmake
 

--- a/.github/workflows/publish-sdist-wheels.yml
+++ b/.github/workflows/publish-sdist-wheels.yml
@@ -66,7 +66,7 @@ jobs:
           C:\windows\system32\tar.exe xf hdf5-1.12.0-Std-win10_64-vs16.zip
           start /wait msiexec /a "%cd%\hdf\HDF5-1.12.0-win64.msi" /qn TARGETDIR="c:\hdf5\"
 
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat" -vcvars_ver=14.2
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat" -vcvars_ver=14.1
 
           set HDF5_DIR=C:\hdf5\HDF_Group\HDF5\1.12.0\cmake
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,16 +5,16 @@ include CMakeLists.txt
 
 # MorphIO submodule dependencies
 include 3rdparty/GSL_LITE/CMakeLists.txt 3rdparty/GSL_LITE/gsl-lite.natvis
-recursive-include 3rdparty/GSL_LITE/cmake/ *
-recursive-include 3rdparty/GSL_LITE/include/ *
+recursive-include 3rdparty/GSL_LITE/cmake *
+recursive-include 3rdparty/GSL_LITE/include *
 
 include 3rdparty/HighFive/CMakeLists.txt
-recursive-include 3rdparty/HighFive/include/ *
-recursive-include 3rdparty/HighFive/CMake/ *
-recursive-include 3rdparty/HighFive/doc/ *
+recursive-include 3rdparty/HighFive/include *
+recursive-include 3rdparty/HighFive/CMake *
+recursive-include 3rdparty/HighFive/doc *
 
 include 3rdparty/lexertl14/CMakeLists.txt
-recursive-include 3rdparty/lexertl14/include/lexertl/ *
+recursive-include 3rdparty/lexertl14/include/lexertl *
 
 # pybind11 for python bindings
 recursive-include binds/python/pybind11/include *


### PR DESCRIPTION
Warning example:
```warning: manifest_maker: MANIFEST.in, line 6: path '3rdparty/GSL_LITE/cmake/' cannot end with '/'```