### PR TITLE
Freeze os versions used for wheel building

### DIFF
--- a/.github/workflows/publish-sdist-wheels.yml
+++ b/.github/workflows/publish-sdist-wheels.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-11, windows-2022]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
In order to avoid implicit os version updates while making a release, the versions are pinned.