### PR TITLE
HDF5 morphologies: rebuild only when options are passed

### DIFF
--- a/src/morphology.cpp
+++ b/src/morphology.cpp
@@ -28,11 +28,9 @@ Morphology::Morphology(const Property::Properties& properties, unsigned int opti
 
     // For SWC and ASC, sanitization and modifier application are already taken care of by
     // their respective loaders
-    if (properties._cellLevel.fileFormat() == "h5") {
+    if (properties._cellLevel.fileFormat() == "h5" && options) {
         mut::Morphology mutable_morph(*this);
-        if (options) {
-            mutable_morph.applyModifiers(options);
-        }
+        mutable_morph.applyModifiers(options);
         properties_ = std::make_shared<Property::Properties>(mutable_morph.buildReadOnly());
         buildChildren(properties_);
     }


### PR DESCRIPTION
Merge the two `if` conditions to avoid additonal work.  This brings the reading time down by a factor of ~4-5 when reading a lot of data:
```
Morphologies		Time [ms] before	Time [ms] after
10			10			2
100			95			23
1000			1017			233
10000			11203			2318
```
