### PR TITLE
Update gsl-lite submodule to v0.40.0

### DIFF
--- a/include/morphio/vector_types.h
+++ b/include/morphio/vector_types.h
@@ -6,7 +6,7 @@
 #include <string>  // std::string
 #include <vector>
 
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 
 namespace morphio {
 

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -1,26 +1,26 @@
 #include <iostream>
 
-static bool almost_equal(morphio::floatType a, double expected, double epsilon) {
+static bool almost_equal(morphio::floatType actual, double expected, double epsilon) {
 #ifdef MORPHIO_USE_DOUBLE
-    bool res = std::abs(a - expected) < epsilon;
+    bool res = std::abs(actual - expected) < epsilon;
 #else
-    bool res = std::abs(static_cast<double>(a) - expected) < epsilon;
+    bool res = std::abs(static_cast<double>(actual) - expected) < epsilon;
 #endif
     if (!res) {
-        std::cerr << "Failed almost equal: " << a << " != " << expected
+        std::cerr << "Failed almost equal: " << actual << " != " << expected
                   << " (expected) with epsilon of " << epsilon << '\n';
     }
     return res;
 }
 
-static bool array_almost_equal(const std::vector<morphio::floatType>& a,
+static bool array_almost_equal(const std::vector<morphio::floatType>& actual,
                                const std::vector<double>& expected,
                                double epsilon) {
-    if (a.size() != expected.size()) {
+    if (actual.size() != expected.size()) {
         return false;
     }
-    for (size_t i = 0; i < a.size(); i++) {
-        if (!almost_equal(a.at(i), expected.at(i), epsilon)) {
+    for (size_t i = 0; i < actual.size(); i++) {
+        if (!almost_equal(actual[i], expected[i], epsilon)) {
             return false;
         }
     }

--- a/tests/test_immutable_morphology.cpp
+++ b/tests/test_immutable_morphology.cpp
@@ -40,9 +40,9 @@ TEST_CASE("fromMut", "[immutableMorphology]") {
     }
     const auto& expectedMorphs = files.morphs();
     for (size_t i = 0; i < expectedMorphs.size(); ++i) {
-        REQUIRE(expectedMorphs.at(i).somaType() == morphs.at(i).somaType());
-        REQUIRE(expectedMorphs.at(i).sectionTypes() == morphs.at(i).sectionTypes());
-        REQUIRE(expectedMorphs.at(i).perimeters() == morphs.at(i).perimeters());
+        REQUIRE(expectedMorphs[i].somaType() == morphs[i].somaType());
+        REQUIRE(expectedMorphs[i].sectionTypes() == morphs[i].sectionTypes());
+        REQUIRE(expectedMorphs[i].perimeters() == morphs[i].perimeters());
     }
 }
 
@@ -61,8 +61,8 @@ TEST_CASE("sections", "[immutableMorphology]") {
     {
         morphio::Morphology morph0 = morphio::Morphology("data/h5/v1/simple.h5");
         morphio::Morphology morph1 = morphio::Morphology("data/h5/v1/simple.h5");
-        REQUIRE(morph0.rootSections().at(0).hasSameShape(morph1.rootSections().at(0)));
-        REQUIRE(!morph0.rootSections().at(0).hasSameShape(morph1.rootSections().at(1)));
+        REQUIRE(morph0.rootSections()[0].hasSameShape(morph1.rootSections()[0]));
+        REQUIRE(!morph0.rootSections()[0].hasSameShape(morph1.rootSections()[1]));
     }
 }
 
@@ -158,7 +158,7 @@ TEST_CASE("properties", "[immutableMorphology]") {
     std::string text;
     uint32_t major = std::numeric_limits<uint32_t>::max();
     uint32_t minor = std::numeric_limits<uint32_t>::max();
-    std::tie(text, major, minor) = files.morphs().at(0).version();
+    std::tie(text, major, minor) = files.morphs()[0].version();
     REQUIRE(text == "asc");
     REQUIRE(major == 1);
     REQUIRE(minor == 0);
@@ -175,12 +175,12 @@ TEST_CASE("iter", "[immutableMorphology]") {
     std::vector<size_t> expectedRootSectionId = {0, 1, 4, 2, 3, 5, 6};
     count = 0;
     for (auto iter = rootSection.breadth_begin(); iter != rootSection.breadth_end(); iter++) {
-        REQUIRE((*iter).id() == expectedRootSectionId.at(count++));
+        REQUIRE((*iter).id() == expectedRootSectionId[count++]);
     }
     std::vector<size_t> expectedMorphSectionId = {0, 7, 1, 4, 8, 9, 2, 3, 5, 6};
     count = 0;
     for (auto iter = iterMorph.breadth_begin(); iter != iterMorph.breadth_end(); iter++) {
-        REQUIRE((*iter).id() == expectedMorphSectionId.at(count++));
+        REQUIRE((*iter).id() == expectedMorphSectionId[count++]);
     }
 
     Files files;
@@ -199,7 +199,7 @@ TEST_CASE("iter", "[immutableMorphology]") {
              iter++) {
             auto points = (*iter).points();
             for (auto point : points) {
-                REQUIRE(point == expectedPoints.at(count++));
+                REQUIRE(point == expectedPoints[count++]);
             }
         }
     }
@@ -229,9 +229,9 @@ TEST_CASE("endoplasmic_reticulum", "[immutableMorphology]") {
     morphio::Morphology morph = morphio::Morphology("data/h5/v1/endoplasmic-reticulum.h5");
     morphio::EndoplasmicReticulum er = morph.endoplasmicReticulum();
     REQUIRE(er.sectionIndices() == std::vector<uint32_t>{1, 4, 5});
-    REQUIRE(almost_equal(er.volumes().at(0), 10.5500001907, 0.001));
-    REQUIRE(almost_equal(er.volumes().at(1), 47.1199989319, 0.001));
-    REQUIRE(almost_equal(er.volumes().at(2), 0.8299999833, 0.001));
+    REQUIRE(almost_equal(er.volumes()[0], 10.5500001907, 0.001));
+    REQUIRE(almost_equal(er.volumes()[1], 47.1199989319, 0.001));
+    REQUIRE(almost_equal(er.volumes()[2], 0.8299999833, 0.001));
     REQUIRE(array_almost_equal(er.surfaceAreas(), std::vector<double>{111.24, 87.44, 0.11}, 0.001));
     REQUIRE(er.filamentCounts() == std::vector<uint32_t>{12, 42, 8});
 }
@@ -258,11 +258,11 @@ TEST_CASE("glia", "[immutableMorphology]") {
     REQUIRE(count_processes == 863);
 
     const auto section = glial.rootSections()[0];
-    REQUIRE(almost_equal(section.diameters().at(0), 2.03101, 0.001));
-    REQUIRE(almost_equal(section.diameters().at(1), 1.86179, 0.001));
+    REQUIRE(almost_equal(section.diameters()[0], 2.03101, 0.001));
+    REQUIRE(almost_equal(section.diameters()[1], 1.86179, 0.001));
 
-    REQUIRE(almost_equal(section.perimeters().at(0), 5.79899, 0.001));
-    REQUIRE(almost_equal(section.perimeters().at(1), 7.98946, 0.001));
+    REQUIRE(almost_equal(section.perimeters()[0], 5.79899, 0.001));
+    REQUIRE(almost_equal(section.perimeters()[1], 7.98946, 0.001));
 
 
     CHECK_THROWS_AS(morphio::GlialCell("data/simple.swc"), morphio::RawDataError);
@@ -272,7 +272,7 @@ TEST_CASE("glia", "[immutableMorphology]") {
 TEST_CASE("markers", "[immutableMorphology]") {
     morphio::Morphology morph = morphio::Morphology("data/pia.asc");
     std::vector<morphio::Property::Marker> markers = morph.markers();
-    REQUIRE(markers.at(0)._label == "pia");
+    REQUIRE(markers[0]._label == "pia");
 }
 
 TEST_CASE("throws", "[immutableMorphology]") {
@@ -289,7 +289,7 @@ TEST_CASE("annotations", "[immutableMorphology]") {
     auto morph = morphio::Morphology(mutMorph);
     REQUIRE(morph.annotations().size() == 1);
 
-    auto annotation = morph.annotations().at(0);
+    auto annotation = morph.annotations()[0];
     REQUIRE(annotation._sectionId == 1);
     REQUIRE(annotation._type == morphio::SINGLE_CHILD);
 }

--- a/tests/test_mitochondria.cpp
+++ b/tests/test_mitochondria.cpp
@@ -16,7 +16,7 @@ TEST_CASE("mitochondria", "[mitochondria]") {
 
     REQUIRE(mito.rootSections().size() == 2);
 
-    auto rootSection = mito.rootSections().at(0);
+    auto rootSection = mito.rootSections()[0];
     REQUIRE(rootSection.id() == 0);
 
     auto diameters = rootSection.diameters();
@@ -27,8 +27,8 @@ TEST_CASE("mitochondria", "[mitochondria]") {
     auto res = std::vector<morphio::floatType>(relativePathLength.begin(),
                                                relativePathLength.end());
 
-    REQUIRE(almost_equal(res.at(0), 0.5, 0.001));
-    REQUIRE(almost_equal(res.at(1), 0.6000000238, 0.001));
+    REQUIRE(almost_equal(res[0], 0.5, 0.001));
+    REQUIRE(almost_equal(res[1], 0.6000000238, 0.001));
 
     auto neuriteSectionIds = rootSection.neuriteSectionIds();
     REQUIRE(array_almost_equal(std::vector<morphio::floatType>(neuriteSectionIds.begin(),
@@ -37,7 +37,7 @@ TEST_CASE("mitochondria", "[mitochondria]") {
                                0.01));
     REQUIRE(rootSection.children().size() == 1);
 
-    auto child = rootSection.children().at(0);
+    auto child = rootSection.children()[0];
     REQUIRE(child.parent().id() == rootSection.id());
 
     diameters = child.diameters();
@@ -56,7 +56,7 @@ TEST_CASE("mitochondria", "[mitochondria]") {
                                                                neuriteSectionIds.end()),
                                std::vector<double>{3.0, 4.0, 4.0, 5.0},
                                0.01));
-    rootSection = mito.rootSections().at(1);
+    rootSection = mito.rootSections()[1];
     diameters = rootSection.diameters();
     REQUIRE(array_almost_equal(std::vector<morphio::floatType>(diameters.begin(), diameters.end()),
                                std::vector<double>{5.0, 6.0, 7.0, 8.0},
@@ -91,7 +91,7 @@ TEST_CASE("mitochondria.sections", "[mitochondria]") {
 TEST_CASE("mitochondria.iteration", "[mitochondria]") {
     const auto mito = morphio::Morphology("data/h5/v1/mitochondria.h5").mitochondria();
 
-    const auto rootSection = mito.rootSections().at(0);
+    const auto rootSection = mito.rootSections()[0];
 
     std::vector<std::size_t> res;
     std::transform(rootSection.depth_begin(),
@@ -118,5 +118,5 @@ TEST_CASE("mitochondria.iteration", "[mitochondria]") {
 TEST_CASE("mitochondria.hasSameShape", "[mitochondria]") {
     morphio::Morphology morph0 = morphio::Morphology("data/h5/v1/mitochondria.h5");
     morphio::Morphology morph1 = morphio::Morphology("data/h5/v1/mitochondria.h5");
-    REQUIRE(morph0.rootSections().at(0).hasSameShape(morph1.rootSections().at(0)));
+    REQUIRE(morph0.rootSections()[0].hasSameShape(morph1.rootSections()[0]));
 }

--- a/tests/test_mutable_morphology.cpp
+++ b/tests/test_mutable_morphology.cpp
@@ -34,15 +34,15 @@ TEST_CASE("hasSameShape", "[mutableMorphology]") {
         std::string path = "data/simple.asc";
         auto morph0 = morphio::mut::Morphology(path);
         auto morph1 = morphio::mut::Morphology(path);
-        REQUIRE(morph0.rootSections().at(0)->hasSameShape(*morph1.rootSections().at(0)));
-        REQUIRE(!morph0.rootSections().at(0)->hasSameShape(*morph1.rootSections().at(1)));
+        REQUIRE(morph0.rootSections()[0]->hasSameShape(*morph1.rootSections()[0]));
+        REQUIRE(!morph0.rootSections()[0]->hasSameShape(*morph1.rootSections()[1]));
     }
     {
         std::string path = "data/h5/v1/mitochondria.h5";
         auto morph0 = morphio::mut::Morphology(path);
         auto morph1 = morphio::mut::Morphology(path);
-        REQUIRE(morph0.mitochondria().rootSections().at(0)->hasSameShape(
-            *morph1.mitochondria().rootSections().at(0)));
+        REQUIRE(morph0.mitochondria().rootSections()[0]->hasSameShape(
+            *morph1.mitochondria().rootSections()[0]));
     }
 }
 


### PR DESCRIPTION
* Updated to gsl-lite `v0.40.0`
* Converted `vector::at` to subscript indexing to remove errors such as:
```
error: 'at' is deprecated: use subscript indexing instead [-Werror,-Wdeprecated-declarations]
```
#390 