### PR TITLE
Update python ci installation command

### DIFF
--- a/ci/python_test.sh
+++ b/ci/python_test.sh
@@ -22,8 +22,7 @@ function create_venv()
 
 # in tree install
 create_venv
-# https://github.com/pypa/pip/issues/7555
-pip install --use-feature=in-tree-build .
+pip install .
 pip install -r tests/requirement_tests.txt
 
 CURRENT=$(pwd)


### PR DESCRIPTION
11 hours ago, pip 22.1 was released (now in use in the CI), which removes the `--use-feature=in-tree-build` option, breaking the building.

https://discuss.python.org/t/announcement-pip-22-1-release/15683