### PR TITLE
Fix section order after deleting sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+v3.3.4
+======
+
+Fixes:
+* Fix wrong section order when section is deleted (#412)
+
 v3.3.3
 ======
 

--- a/include/morphio/mut/morphology.h
+++ b/include/morphio/mut/morphology.h
@@ -180,7 +180,7 @@ class Morphology
     }
 
     /// Write file to H5, SWC, ASC format depending on filename extension
-    void write(const std::string& filename);
+    void write(const std::string& filename) const;
 
     void addAnnotation(const morphio::Property::Annotation& annotation) {
         _cellProperties->_annotations.push_back(annotation);

--- a/src/mut/morphology.cpp
+++ b/src/mut/morphology.cpp
@@ -177,7 +177,7 @@ void Morphology::eraseByValue(std::vector<std::shared_ptr<Section>>& vec,
 
 
 void inline insertSectionsBeforeSection(std::vector<std::shared_ptr<Section>>& sections_to_update,
-                                        const std::vector<std::shared_ptr<Section>> sections,
+                                        const std::vector<std::shared_ptr<Section>>& sections,
                                         uint32_t section_id) {
     // find where the section_id is located in sections_to_update and insert the sections
     // before that. Note that the section with section_id is not removed at this step

--- a/src/mut/morphology.cpp
+++ b/src/mut/morphology.cpp
@@ -1,4 +1,4 @@
-#include <algorithm>
+#include <algorithm>  // std::find_if
 #include <cassert>
 #include <cctype>    // std::tolower
 #include <iterator>  // std::back_inserter

--- a/src/mut/morphology.cpp
+++ b/src/mut/morphology.cpp
@@ -208,7 +208,7 @@ void Morphology::deleteSection(std::shared_ptr<Section> section_, bool recursive
     } else {
         // Careful not to use a reference here or you will face reference invalidation problem
         // with vector resize
-        auto children = section_->children();
+        const auto children = section_->children();
 
         if (section_->isRoot()) {
             // put root section's children in its place

--- a/src/mut/morphology.cpp
+++ b/src/mut/morphology.cpp
@@ -1,5 +1,6 @@
+#include <algorithm>
 #include <cassert>
-#include <cctype>  // std::tolower
+#include <cctype>    // std::tolower
 #include <iterator>  // std::back_inserter
 #include <sstream>
 #include <string>
@@ -179,14 +180,17 @@ void Morphology::eraseByValue(std::vector<std::shared_ptr<Section>>& vec,
 void inline insertSectionsBeforeSection(std::vector<std::shared_ptr<Section>>& sections_to_update,
                                         const std::vector<std::shared_ptr<Section>>& sections,
                                         uint32_t section_id) {
-    // find where the section_id is located in sections_to_update and insert the sections
-    // before that. Note that the section with section_id is not removed at this step
-    for (auto it = sections_to_update.begin(); it != sections_to_update.end(); ++it) {
-        if ((*it)->id() == section_id) {
-            sections_to_update.insert(it, sections.begin(), sections.end());
-            break;
-        }
-    }
+    // lambda to check if a section has the given id
+    auto equals_section_id = [section_id](const std::shared_ptr<Section>& section) {
+        return section->id() == section_id;
+    };
+
+    // get the iterator to the section with section_id in sections_to_update
+    auto it = std::find_if(sections_to_update.begin(), sections_to_update.end(), equals_section_id);
+
+    // Insert the sections at this poisition
+    // Note that the section with section_id is not removed at this step
+    sections_to_update.insert(it, sections.begin(), sections.end());
 }
 
 void Morphology::deleteSection(std::shared_ptr<Section> section_, bool recursive) {

--- a/src/mut/morphology.cpp
+++ b/src/mut/morphology.cpp
@@ -179,10 +179,10 @@ void Morphology::eraseByValue(std::vector<std::shared_ptr<Section>>& vec,
 
 void inline insertSectionsBeforeSection(std::vector<std::shared_ptr<Section>>& sections_to_update,
                                         const std::vector<std::shared_ptr<Section>>& sections,
-                                        uint32_t section_id) {
+                                        const std::shared_ptr<Section>& target_section) {
     // lambda to check if a section has the given id
-    auto equals_section_id = [section_id](const std::shared_ptr<Section>& section) {
-        return section->id() == section_id;
+    auto equals_section_id = [&target_section](const std::shared_ptr<Section>& section) {
+        return (section->id() == target_section->id()) && section->hasSameShape(*target_section);
     };
 
     // get the iterator to the section with section_id in sections_to_update
@@ -216,7 +216,7 @@ void Morphology::deleteSection(std::shared_ptr<Section> section_, bool recursive
 
         if (section_->isRoot()) {
             // put root section's children in its place
-            insertSectionsBeforeSection(_rootSections, children, id);
+            insertSectionsBeforeSection(_rootSections, children, section_);
             eraseByValue(_rootSections, section_);
         } else {
             // set grandparent as section children's parent
@@ -227,7 +227,7 @@ void Morphology::deleteSection(std::shared_ptr<Section> section_, bool recursive
             auto& children_of_parent = _children[_parent[id]];
 
             // put grandchildren at the position of the deleted section
-            insertSectionsBeforeSection(children_of_parent, children, id);
+            insertSectionsBeforeSection(children_of_parent, children, section_);
             eraseByValue(children_of_parent, section_);
         }
 

--- a/src/mut/morphology.cpp
+++ b/src/mut/morphology.cpp
@@ -181,12 +181,12 @@ void inline insertSectionsBeforeSection(std::vector<std::shared_ptr<Section>>& s
                                         const std::vector<std::shared_ptr<Section>>& sections,
                                         const std::shared_ptr<Section>& target_section) {
     // lambda to check if a section has the given id
-    auto equals_section_id = [&target_section](const std::shared_ptr<Section>& section) {
+    auto is_equal = [&target_section](const std::shared_ptr<Section>& section) {
         return (section->id() == target_section->id()) && section->hasSameShape(*target_section);
     };
 
     // get the iterator to the section with section_id in sections_to_update
-    auto it = std::find_if(sections_to_update.begin(), sections_to_update.end(), equals_section_id);
+    auto it = std::find_if(sections_to_update.begin(), sections_to_update.end(), is_equal);
 
     // Insert the sections at this position
     // Note that the section with section_id is not removed at this step

--- a/src/mut/morphology.cpp
+++ b/src/mut/morphology.cpp
@@ -176,7 +176,7 @@ void Morphology::eraseByValue(std::vector<std::shared_ptr<Section>>& vec,
 }
 
 
-void inline insertSectionsInPlaceOfSection(
+void inline insertSectionsBeforeSection(
     std::vector<std::shared_ptr<Section>>& sections_to_update,
     const std::vector<std::shared_ptr<Section>> sections,
     uint32_t section_id) {
@@ -213,14 +213,14 @@ void Morphology::deleteSection(std::shared_ptr<Section> section_, bool recursive
 
         if (section_->isRoot()) {
             // put root section's children in its place
-            insertSectionsInPlaceOfSection(_rootSections, children, id);
+            insertSectionsBeforeSection(_rootSections, children, id);
         } else {
             // set grandparent as section children's parent
             for (auto child : children) {
                 _parent[child->id()] = _parent[id];
             }
             // put grandchildren at the position of the deleted section
-            insertSectionsInPlaceOfSection(_children[_parent[id]], children, id);
+            insertSectionsBeforeSection(_children[_parent[id]], children, id);
         }
 
         eraseByValue(_rootSections, section_);

--- a/src/mut/morphology.cpp
+++ b/src/mut/morphology.cpp
@@ -180,7 +180,6 @@ void Morphology::eraseByValue(std::vector<std::shared_ptr<Section>>& vec,
 void inline insertSectionsBeforeSection(std::vector<std::shared_ptr<Section>>& sections_to_update,
                                         const std::vector<std::shared_ptr<Section>>& sections,
                                         const std::shared_ptr<Section>& target_section) {
-
     auto is_equal = [&target_section](const std::shared_ptr<Section>& section) {
         return (section->id() == target_section->id()) && section->hasSameShape(*target_section);
     };

--- a/src/mut/morphology.cpp
+++ b/src/mut/morphology.cpp
@@ -180,15 +180,13 @@ void Morphology::eraseByValue(std::vector<std::shared_ptr<Section>>& vec,
 void inline insertSectionsBeforeSection(std::vector<std::shared_ptr<Section>>& sections_to_update,
                                         const std::vector<std::shared_ptr<Section>>& sections,
                                         const std::shared_ptr<Section>& target_section) {
-    // lambda to check if a section has the given id
+
     auto is_equal = [&target_section](const std::shared_ptr<Section>& section) {
         return (section->id() == target_section->id()) && section->hasSameShape(*target_section);
     };
 
-    // get the iterator to the section with section_id in sections_to_update
     auto it = std::find_if(sections_to_update.begin(), sections_to_update.end(), is_equal);
 
-    // Insert the sections at this position
     // Note that the section with section_id is not removed at this step
     sections_to_update.insert(it, sections.begin(), sections.end());
 }

--- a/src/mut/morphology.cpp
+++ b/src/mut/morphology.cpp
@@ -192,7 +192,6 @@ void Morphology::deleteSection(std::shared_ptr<Section> section_, bool recursive
             deleteSection(*it, false);
         }
     } else {
-
         // Careful not to use a reference here or you will face reference invalidation problem
         // with vector resize
         auto children = section_->children();
@@ -206,16 +205,15 @@ void Morphology::deleteSection(std::shared_ptr<Section> section_, bool recursive
                 }
             }
         } else {
-
             // set grandparent as section children's parent
-            for (auto child: children) {
-                 _parent[child->id()] = _parent[id];
+            for (auto child : children) {
+                _parent[child->id()] = _parent[id];
             }
 
             // put grandchildren at the position of the deleted section
             auto& parent_children = _children[_parent[id]];
 
-            for ( auto it = parent_children.begin(); it != parent_children.end(); ++it) {
+            for (auto it = parent_children.begin(); it != parent_children.end(); ++it) {
                 if ((*it)->id() == id) {
                     parent_children.insert(it, children.begin(), children.end());
                     break;

--- a/src/mut/morphology.cpp
+++ b/src/mut/morphology.cpp
@@ -188,7 +188,7 @@ void inline insertSectionsBeforeSection(std::vector<std::shared_ptr<Section>>& s
     // get the iterator to the section with section_id in sections_to_update
     auto it = std::find_if(sections_to_update.begin(), sections_to_update.end(), equals_section_id);
 
-    // Insert the sections at this poisition
+    // Insert the sections at this position
     // Note that the section with section_id is not removed at this step
     sections_to_update.insert(it, sections.begin(), sections.end());
 }

--- a/src/mut/morphology.cpp
+++ b/src/mut/morphology.cpp
@@ -213,17 +213,21 @@ void Morphology::deleteSection(std::shared_ptr<Section> section_, bool recursive
         if (section_->isRoot()) {
             // put root section's children in its place
             insertSectionsBeforeSection(_rootSections, children, id);
+            eraseByValue(_rootSections, section_);
         } else {
             // set grandparent as section children's parent
             for (auto child : children) {
                 _parent[child->id()] = _parent[id];
             }
+
+            auto& children_of_parent = _children[_parent[id]];
+
             // put grandchildren at the position of the deleted section
-            insertSectionsBeforeSection(_children[_parent[id]], children, id);
+            insertSectionsBeforeSection(children_of_parent, children, id);
+            eraseByValue(children_of_parent, section_);
         }
 
-        eraseByValue(_rootSections, section_);
-        eraseByValue(_children[_parent[id]], section_);
+        // remove section id from connectivity and section lists
         _children.erase(id);
         _parent.erase(id);
         _sections.erase(id);

--- a/src/mut/morphology.cpp
+++ b/src/mut/morphology.cpp
@@ -176,10 +176,9 @@ void Morphology::eraseByValue(std::vector<std::shared_ptr<Section>>& vec,
 }
 
 
-void inline insertSectionsBeforeSection(
-    std::vector<std::shared_ptr<Section>>& sections_to_update,
-    const std::vector<std::shared_ptr<Section>> sections,
-    uint32_t section_id) {
+void inline insertSectionsBeforeSection(std::vector<std::shared_ptr<Section>>& sections_to_update,
+                                        const std::vector<std::shared_ptr<Section>> sections,
+                                        uint32_t section_id) {
     // find where the section_id is located in sections_to_update and insert the sections
     // before that. Note that the section with section_id is not removed at this step
     for (auto it = sections_to_update.begin(); it != sections_to_update.end(); ++it) {

--- a/tests/test_5_mut.py
+++ b/tests/test_5_mut.py
@@ -718,195 +718,175 @@ def _assert_sections_equal(morph1, morph2, section_ids):
 
 
 def test_delete_section__maintain_children_order_non_root_section(tmp_path):
+    string = """
+    ("CellBody"
+      (Color Red)
+      (CellBody)
+      ( 0.1  0.1 0.0 0.1)
+      ( 0.1 -0.1 0.0 0.1)
+    )
 
-    with tmp_asc_file(
-        tmp_path,
-        """
-        ("CellBody"
-          (Color Red)
-          (CellBody)
-          ( 0.1  0.1 0.0 0.1)
-          ( 0.1 -0.1 0.0 0.1)
+    ( (Color Cyan)
+      (Axon)
+      (0.0  0.0 0.0 2.0) ; section 0
+      (0.0 -4.0 1.0 2.0)
+      (
+        (0.0 -4.0 1.0 4.0) ; section 1
+        (0.0 -4.0 2.0 4.0)
+        (0.0 -4.0 3.0 4.0)
+        (
+            (6.0 -4.0 0.0 4.0) ; section 2
+            (7.0 -5.0 0.0 4.0)
+        |
+            (6.0 -4.0 0.0 4.0) ; section 3
+            (8.0 -4.0 0.0 4.0)
         )
+      |
+        ( 0.0 -4.0 1.0 4.0) ; section 4
+        (-5.0 -4.0 0.0 4.0)
+      )
+    )
+    """
+    morph = ImmutableMorphology(string, "asc").as_mutable()
 
-        ( (Color Cyan)
-          (Axon)
-          (0.0  0.0 0.0 2.0) ; section 0
-          (0.0 -4.0 1.0 2.0)
-          (
-            (0.0 -4.0 1.0 4.0) ; section 1
-            (0.0 -4.0 2.0 4.0)
-            (0.0 -4.0 3.0 4.0)
-            (
-                (6.0 -4.0 0.0 4.0) ; section 2
-                (7.0 -5.0 0.0 4.0)
-            |
-                (6.0 -4.0 0.0 4.0) ; section 3
-                (8.0 -4.0 0.0 4.0)
-            )
-          |
-            ( 0.0 -4.0 1.0 4.0) ; section 4
-            (-5.0 -4.0 0.0 4.0)
-          )
-        )
-        """
-    ) as tfile:
+    axon = morph.root_sections[0]
+    to_be_removed_section = axon.children[0]
+    morph.delete_section(to_be_removed_section, recursive=False)
 
-        filepath = tfile.name
+    assert [s.id for s in morph.iter()] == [0, 2, 3, 4]
 
-        # make copy to compare afterwards
-        morph = Morphology(filepath)
+    # a trifurcation is made
+    assert [s.id for s in axon.children] == [2, 3, 4]
 
-        axon = morph.root_sections[0]
-        to_be_removed_section = axon.children[0]
-        morph.delete_section(to_be_removed_section, recursive=False)
+    # ensure nothing has been added to the leaves
+    for child in axon.children:
+        assert child.children == []
 
-        assert [s.id for s in morph.iter()] == [0, 2, 3, 4]
-
-        # a trifurcation is made
-        assert [s.id for s in axon.children] == [2, 3, 4]
-
-        # ensure nothing has been added to the leaves
-        for child in axon.children:
-            assert child.children == []
-
-        # check that data has not been messed up
-        original = Morphology(filepath)
-        _assert_sections_equal(morph, original, [0, 2, 3, 4])
+    # check that data has not been messed up
+    original = ImmutableMorphology(string, "asc").as_mutable()
+    _assert_sections_equal(morph, original, [0, 2, 3, 4])
 
 
 def test_delete_section__maintain_children_order_non_root_section_multiple(tmp_path):
-    with tmp_asc_file(
-        tmp_path,
-        """
-        ("CellBody"
-          (Color Red)
-          (CellBody)
-          ( 0.1  0.1 0.0 0.1)
-          ( 0.1 -0.1 0.0 0.1)
-        )
+    string = """
+    ("CellBody"
+      (Color Red)
+      (CellBody)
+      ( 0.1  0.1 0.0 0.1)
+      ( 0.1 -0.1 0.0 0.1)
+    )
 
-        ( (Color Cyan)
-          (Axon)
-          (0.0  0.0 0.0 2.0) ; section 0
-          (0.0 -4.0 1.0 2.0)
-          (
-            (0.0 -4.0 1.0 4.0) ; section 1
-            (0.0 -4.0 2.0 4.0)
-            (0.0 -4.0 3.0 4.0)
+    ( (Color Cyan)
+      (Axon)
+      (0.0  0.0 0.0 2.0) ; section 0
+      (0.0 -4.0 1.0 2.0)
+      (
+        (0.0 -4.0 1.0 4.0) ; section 1
+        (0.0 -4.0 2.0 4.0)
+        (0.0 -4.0 3.0 4.0)
+        (
+            (6.0 -4.0 0.0 4.0) ; section 2
+            (7.0 -5.0 0.0 4.0)
             (
-                (6.0 -4.0 0.0 4.0) ; section 2
-                (7.0 -5.0 0.0 4.0)
-                (
-                    (8.0 -4.0 0.0 4.0) ; section 3
-                    (8.0 -5.0 0.0 4.0)
-                |
-                    (8.0 -4.0 0.0 4.0) ; section 4
-                    (8.0 -5.0 0.0 4.0)
-                )
+                (8.0 -4.0 0.0 4.0) ; section 3
+                (8.0 -5.0 0.0 4.0)
             |
-                (6.0 -4.0 0.0 4.0) ; section 5
-                (8.0 -4.0 0.0 4.0)
+                (8.0 -4.0 0.0 4.0) ; section 4
+                (8.0 -5.0 0.0 4.0)
             )
-          |
-            ( 0.0 -4.0 1.0 4.0) ; section 6
-            (-5.0 -4.0 0.0 4.0)
-            (
-                (3.0 2.0 1.0 4.0) ; section 7
-                (3.0 2.0 0.0 4.0)
-            |
-                (2.0 3.0 1.0 4.0) ; section 8
-                (2.0 3.0 0.0 4.0)
-            )
-          )
+        |
+            (6.0 -4.0 0.0 4.0) ; section 5
+            (8.0 -4.0 0.0 4.0)
         )
-        """
-    ) as tfile:
+      |
+        ( 0.0 -4.0 1.0 4.0) ; section 6
+        (-5.0 -4.0 0.0 4.0)
+        (
+            (3.0 2.0 1.0 4.0) ; section 7
+            (3.0 2.0 0.0 4.0)
+        |
+            (2.0 3.0 1.0 4.0) ; section 8
+            (2.0 3.0 0.0 4.0)
+        )
+      )
+    )
+    """
+    morph = ImmutableMorphology(string, "asc").as_mutable()
 
-        filepath = tfile.name
+    morph.delete_section(morph.section(0), recursive=False)
+    morph.delete_section(morph.section(1), recursive=False)
+    morph.delete_section(morph.section(4), recursive=False)
+    morph.delete_section(morph.section(7), recursive=False)
 
-        morph = Morphology(filepath)
+    assert [s.id for s in morph.iter()] == [2, 3, 5, 6, 8]
+    assert [s.id for s in morph.root_sections] == [2, 5, 6]
 
-        morph.delete_section(morph.section(0), recursive=False)
-        morph.delete_section(morph.section(1), recursive=False)
-        morph.delete_section(morph.section(4), recursive=False)
-        morph.delete_section(morph.section(7), recursive=False)
+    # made unifurcations
+    assert [s.id for s in morph.section(2).children] == [3]
+    assert [s.id for s in morph.section(6).children] == [8]
 
-        assert [s.id for s in morph.iter()] == [2, 3, 5, 6, 8]
-        assert [s.id for s in morph.root_sections] == [2, 5, 6]
+    # ensure nothing has been added to the leaves
+    for leaf_id in [3, 5, 8]:
+        assert morph.section(leaf_id).children == []
 
-        # made unifurcations
-        assert [s.id for s in morph.section(2).children] == [3]
-        assert [s.id for s in morph.section(6).children] == [8]
-
-        # ensure nothing has been added to the leaves
-        for leaf_id in [3, 5, 8]:
-            assert morph.section(leaf_id).children == []
-
-        # check that data has not been messed up
-        original = Morphology(filepath)
-        _assert_sections_equal(morph, original, [2, 3, 5, 6, 8])
+    # check that data has not been messed up
+    original = ImmutableMorphology(string, "asc").as_mutable()
+    _assert_sections_equal(morph, original, [2, 3, 5, 6, 8])
 
 
 def test_delete_section__maintain_children_order_root_section(tmp_path):
-    with tmp_asc_file(
-        tmp_path,
-        """
-        ("CellBody"
-          (Color Red)
-          (CellBody)
-          ( 0.1  0.1 0.0 0.1)
-          ( 0.1 -0.1 0.0 0.1)
+    string = """
+    ("CellBody"
+      (Color Red)
+      (CellBody)
+      ( 0.1  0.1 0.0 0.1)
+      ( 0.1 -0.1 0.0 0.1)
+    )
+
+    ( (Color Cyan)
+      (Axon)
+      (0.0  0.0 0.0 2.0) ; section 0
+      (0.0 -4.0 1.0 2.0)
+      (
+        (0.0 -4.0 1.0 4.0) ; section 1
+        (0.0 -4.0 2.0 4.0)
+        (0.0 -4.0 3.0 4.0)
+        (
+            (6.0 -4.0 0.0 4.0) ; section 2
+            (7.0 -5.0 0.0 4.0)
+        |
+            (6.0 -4.0 0.0 4.0) ; section 3
+            (8.0 -4.0 0.0 4.0)
         )
+      |
+        ( 0.0 -4.0 1.0 4.0) ; section 4
+        (-5.0 -4.0 0.0 4.0)
+      )
+    )
 
-        ( (Color Cyan)
-          (Axon)
-          (0.0  0.0 0.0 2.0) ; section 0
-          (0.0 -4.0 1.0 2.0)
-          (
-            (0.0 -4.0 1.0 4.0) ; section 1
-            (0.0 -4.0 2.0 4.0)
-            (0.0 -4.0 3.0 4.0)
-            (
-                (6.0 -4.0 0.0 4.0) ; section 2
-                (7.0 -5.0 0.0 4.0)
-            |
-                (6.0 -4.0 0.0 4.0) ; section 3
-                (8.0 -4.0 0.0 4.0)
-            )
-          |
-            ( 0.0 -4.0 1.0 4.0) ; section 4
-            (-5.0 -4.0 0.0 4.0)
-          )
-        )
+    ( (Color Cyan)
+      (Dendrite)
+      (1.0  1.0 1.0 2.0) ; section 5
+      (1.0  1.0 2.0 2.0)
+    )
+    """
+    morph = ImmutableMorphology(string, "asc").as_mutable()
 
-        ( (Color Cyan)
-          (Dendrite)
-          (1.0  1.0 1.0 2.0) ; section 5
-          (1.0  1.0 2.0 2.0)
-        )
-        """
-    ) as tfile:
+    root = morph.root_sections[0]
+    morph.delete_section(root, recursive=False)
 
-        filepath = tfile.name
+    assert [s.id for s in morph.iter()] == [1, 2, 3, 4, 5]
 
-        morph = Morphology(filepath)
+    # the children of root 0 are put in its place
+    assert [s.id for s in morph.root_sections] == [1, 4, 5]
+    assert [s.id for s in morph.root_sections[0].children] == [2, 3]
+    assert [s.id for s in morph.root_sections[1].children] == []
+    assert [s.id for s in morph.root_sections[2].children] == []
 
-        root = morph.root_sections[0]
-        morph.delete_section(root, recursive=False)
+    # check that nothing has been added to the leaves
+    for section_id in [2, 3, 4, 5]:
+        assert morph.section(section_id).children == []
 
-        assert [s.id for s in morph.iter()] == [1, 2, 3, 4, 5]
-
-        # the children of root 0 are put in its place
-        assert [s.id for s in morph.root_sections] == [1, 4, 5]
-        assert [s.id for s in morph.root_sections[0].children] == [2, 3]
-        assert [s.id for s in morph.root_sections[1].children] == []
-        assert [s.id for s in morph.root_sections[2].children] == []
-
-        # check that nothing has been added to the leaves
-        for section_id in [2, 3, 4, 5]:
-            assert morph.section(section_id).children == []
-
-        # check that data has not been messed up
-        original = Morphology(filepath)
-        _assert_sections_equal(morph, original, [1, 2, 3, 4, 5])
+    # check that data has not been messed up
+    original = ImmutableMorphology(string, "asc").as_mutable()
+    _assert_sections_equal(morph, original, [1, 2, 3, 4, 5])

--- a/tests/test_5_mut.py
+++ b/tests/test_5_mut.py
@@ -717,41 +717,42 @@ def _assert_sections_equal(morph1, morph2, section_ids):
         npt.assert_array_equal(s1.diameters, s2.diameters)
 
 
-def test_delete_section__maintain_children_order_non_root_section():
-    with tempfile.NamedTemporaryFile(suffix=".asc") as tfile:
-        filepath = tfile.name
-        with open(filepath, "w") as f:
-            f.write(
-                """
-                ("CellBody"
-                  (Color Red)
-                  (CellBody)
-                  ( 0.1  0.1 0.0 0.1)
-                  ( 0.1 -0.1 0.0 0.1)
-                )
+def test_delete_section__maintain_children_order_non_root_section(tmp_path):
 
-                ( (Color Cyan)
-                  (Axon)
-                  (0.0  0.0 0.0 2.0) ; section 0
-                  (0.0 -4.0 1.0 2.0)
-                  (
-                    (0.0 -4.0 1.0 4.0) ; section 1
-                    (0.0 -4.0 2.0 4.0)
-                    (0.0 -4.0 3.0 4.0)
-                    (
-                        (6.0 -4.0 0.0 4.0) ; section 2
-                        (7.0 -5.0 0.0 4.0)
-                    |
-                        (6.0 -4.0 0.0 4.0) ; section 3
-                        (8.0 -4.0 0.0 4.0)
-                    )
-                  |
-                    ( 0.0 -4.0 1.0 4.0) ; section 4
-                    (-5.0 -4.0 0.0 4.0)
-                  )
-                )
-                """
+    with tmp_asc_file(
+        tmp_path,
+        """
+        ("CellBody"
+          (Color Red)
+          (CellBody)
+          ( 0.1  0.1 0.0 0.1)
+          ( 0.1 -0.1 0.0 0.1)
+        )
+
+        ( (Color Cyan)
+          (Axon)
+          (0.0  0.0 0.0 2.0) ; section 0
+          (0.0 -4.0 1.0 2.0)
+          (
+            (0.0 -4.0 1.0 4.0) ; section 1
+            (0.0 -4.0 2.0 4.0)
+            (0.0 -4.0 3.0 4.0)
+            (
+                (6.0 -4.0 0.0 4.0) ; section 2
+                (7.0 -5.0 0.0 4.0)
+            |
+                (6.0 -4.0 0.0 4.0) ; section 3
+                (8.0 -4.0 0.0 4.0)
             )
+          |
+            ( 0.0 -4.0 1.0 4.0) ; section 4
+            (-5.0 -4.0 0.0 4.0)
+          )
+        )
+        """
+    ) as tfile:
+
+        filepath = tfile.name
 
         # make copy to compare afterwards
         morph = Morphology(filepath)
@@ -774,55 +775,56 @@ def test_delete_section__maintain_children_order_non_root_section():
         _assert_sections_equal(morph, original, [0, 2, 3, 4])
 
 
-def test_delete_section__maintain_children_order_non_root_section_multiple():
-    with tempfile.NamedTemporaryFile(suffix=".asc") as tfile:
-        filepath = tfile.name
-        with open(filepath, "w") as f:
-            f.write(
-                """
-                ("CellBody"
-                  (Color Red)
-                  (CellBody)
-                  ( 0.1  0.1 0.0 0.1)
-                  ( 0.1 -0.1 0.0 0.1)
-                )
+def test_delete_section__maintain_children_order_non_root_section_multiple(tmp_path):
+    with tmp_asc_file(
+        tmp_path,
+        """
+        ("CellBody"
+          (Color Red)
+          (CellBody)
+          ( 0.1  0.1 0.0 0.1)
+          ( 0.1 -0.1 0.0 0.1)
+        )
 
-                ( (Color Cyan)
-                  (Axon)
-                  (0.0  0.0 0.0 2.0) ; section 0
-                  (0.0 -4.0 1.0 2.0)
-                  (
-                    (0.0 -4.0 1.0 4.0) ; section 1
-                    (0.0 -4.0 2.0 4.0)
-                    (0.0 -4.0 3.0 4.0)
-                    (
-                        (6.0 -4.0 0.0 4.0) ; section 2
-                        (7.0 -5.0 0.0 4.0)
-                        (
-                            (8.0 -4.0 0.0 4.0) ; section 3
-                            (8.0 -5.0 0.0 4.0)
-                        |
-                            (8.0 -4.0 0.0 4.0) ; section 4
-                            (8.0 -5.0 0.0 4.0)
-                        )
-                    |
-                        (6.0 -4.0 0.0 4.0) ; section 5
-                        (8.0 -4.0 0.0 4.0)
-                    )
-                  |
-                    ( 0.0 -4.0 1.0 4.0) ; section 6
-                    (-5.0 -4.0 0.0 4.0)
-                    (
-                        (3.0 2.0 1.0 4.0) ; section 7
-                        (3.0 2.0 0.0 4.0)
-                    |
-                        (2.0 3.0 1.0 4.0) ; section 8
-                        (2.0 3.0 0.0 4.0)
-                    )
-                  )
+        ( (Color Cyan)
+          (Axon)
+          (0.0  0.0 0.0 2.0) ; section 0
+          (0.0 -4.0 1.0 2.0)
+          (
+            (0.0 -4.0 1.0 4.0) ; section 1
+            (0.0 -4.0 2.0 4.0)
+            (0.0 -4.0 3.0 4.0)
+            (
+                (6.0 -4.0 0.0 4.0) ; section 2
+                (7.0 -5.0 0.0 4.0)
+                (
+                    (8.0 -4.0 0.0 4.0) ; section 3
+                    (8.0 -5.0 0.0 4.0)
+                |
+                    (8.0 -4.0 0.0 4.0) ; section 4
+                    (8.0 -5.0 0.0 4.0)
                 )
-                """
+            |
+                (6.0 -4.0 0.0 4.0) ; section 5
+                (8.0 -4.0 0.0 4.0)
             )
+          |
+            ( 0.0 -4.0 1.0 4.0) ; section 6
+            (-5.0 -4.0 0.0 4.0)
+            (
+                (3.0 2.0 1.0 4.0) ; section 7
+                (3.0 2.0 0.0 4.0)
+            |
+                (2.0 3.0 1.0 4.0) ; section 8
+                (2.0 3.0 0.0 4.0)
+            )
+          )
+        )
+        """
+    ) as tfile:
+
+        filepath = tfile.name
+
         morph = Morphology(filepath)
 
         morph.delete_section(morph.section(0), recursive=False)
@@ -846,47 +848,48 @@ def test_delete_section__maintain_children_order_non_root_section_multiple():
         _assert_sections_equal(morph, original, [2, 3, 5, 6, 8])
 
 
-def test_delete_section__maintain_children_order_root_section():
-    with tempfile.NamedTemporaryFile(suffix=".asc") as tfile:
-        filepath = tfile.name
-        with open(filepath, "w") as f:
-            f.write(
-                """
-                ("CellBody"
-                  (Color Red)
-                  (CellBody)
-                  ( 0.1  0.1 0.0 0.1)
-                  ( 0.1 -0.1 0.0 0.1)
-                )
+def test_delete_section__maintain_children_order_root_section(tmp_path):
+    with tmp_asc_file(
+        tmp_path,
+        """
+        ("CellBody"
+          (Color Red)
+          (CellBody)
+          ( 0.1  0.1 0.0 0.1)
+          ( 0.1 -0.1 0.0 0.1)
+        )
 
-                ( (Color Cyan)
-                  (Axon)
-                  (0.0  0.0 0.0 2.0) ; section 0
-                  (0.0 -4.0 1.0 2.0)
-                  (
-                    (0.0 -4.0 1.0 4.0) ; section 1
-                    (0.0 -4.0 2.0 4.0)
-                    (0.0 -4.0 3.0 4.0)
-                    (
-                        (6.0 -4.0 0.0 4.0) ; section 2
-                        (7.0 -5.0 0.0 4.0)
-                    |
-                        (6.0 -4.0 0.0 4.0) ; section 3
-                        (8.0 -4.0 0.0 4.0)
-                    )
-                  |
-                    ( 0.0 -4.0 1.0 4.0) ; section 4
-                    (-5.0 -4.0 0.0 4.0)
-                  )
-                )
-
-                ( (Color Cyan)
-                  (Dendrite)
-                  (1.0  1.0 1.0 2.0) ; section 5
-                  (1.0  1.0 2.0 2.0)
-                )
-                """
+        ( (Color Cyan)
+          (Axon)
+          (0.0  0.0 0.0 2.0) ; section 0
+          (0.0 -4.0 1.0 2.0)
+          (
+            (0.0 -4.0 1.0 4.0) ; section 1
+            (0.0 -4.0 2.0 4.0)
+            (0.0 -4.0 3.0 4.0)
+            (
+                (6.0 -4.0 0.0 4.0) ; section 2
+                (7.0 -5.0 0.0 4.0)
+            |
+                (6.0 -4.0 0.0 4.0) ; section 3
+                (8.0 -4.0 0.0 4.0)
             )
+          |
+            ( 0.0 -4.0 1.0 4.0) ; section 4
+            (-5.0 -4.0 0.0 4.0)
+          )
+        )
+
+        ( (Color Cyan)
+          (Dendrite)
+          (1.0  1.0 1.0 2.0) ; section 5
+          (1.0  1.0 2.0 2.0)
+        )
+        """
+    ) as tfile:
+
+        filepath = tfile.name
+
         morph = Morphology(filepath)
 
         root = morph.root_sections[0]

--- a/tests/test_morphology_readers.cpp
+++ b/tests/test_morphology_readers.cpp
@@ -3,6 +3,7 @@
 
 #include <highfive/H5File.hpp>
 #include <morphio/dendritic_spine.h>
+#include <morphio/enums.h>
 #include <morphio/morphology.h>
 #include <morphio/mut/morphology.h>
 #include <morphio/soma.h>
@@ -40,6 +41,15 @@ TEST_CASE("LoadH5Morphology", "[morphology]") {
         REQUIRE(m.points().size() == 12);
         // 2 point soma
         REQUIRE(m.somaType() == morphio::SomaType::SOMA_UNDEFINED);
+    }
+
+    {
+        // This is to cover the appendProperties perimeters line in mut/morphology.cpp,
+        // which is triggered if modifiers are used in a morphology that has perimeters
+        const morphio::Morphology m("data/h5/v1/glia.h5", morphio::enums::Option::NRN_ORDER);
+        REQUIRE(m.soma().points().size() == 2);
+        REQUIRE(m.points().size() == 2);
+        REQUIRE(m.perimeters().size() == 2);
     }
 
     {  // file is an not a valid h5 file
@@ -89,7 +99,6 @@ TEST_CASE("LoadH5Morphology", "[morphology]") {
     }
 }
 
-
 TEST_CASE("LoadH5Glia", "[morphology]") {
     {
         const morphio::Morphology m("data/h5/v1/glia.h5");
@@ -97,7 +106,6 @@ TEST_CASE("LoadH5Glia", "[morphology]") {
         REQUIRE(m.points().size() == 2);
         REQUIRE(m.perimeters().size() == 2);
     }
-
     {
         const morphio::Morphology m("data/h5/v1/glia_soma_only.h5");
         REQUIRE(m.soma().points().size() == 1);


### PR DESCRIPTION
**Issue:** When a section is deleted, its children are added to the parent's children (or as root sections) at the end of the vector. This results in changing the traversal sequence due to the children not being added in place of the deleted section.

**Changes:** Upon section deletion, the section's children are added to the parent's children (or at root sections) at the position of the deleted section, instead of the end of the vector.

Fixes #410 