### PR TITLE
cleanup mutable morphology

### DIFF
--- a/include/morphio/mut/morphology.h
+++ b/include/morphio/mut/morphology.h
@@ -2,6 +2,7 @@
 
 #include <map>
 #include <memory>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -40,76 +41,80 @@ class Morphology
     **/
     explicit Morphology(const std::string& uri, unsigned int options = NO_MODIFIER);
 
-    /**
-       Build a mutable Morphology from a mutable morphology
-    **/
+    /// Build a mutable Morphology from a mutable morphology aaaaaa
     Morphology(const morphio::mut::Morphology& morphology, unsigned int options = NO_MODIFIER);
 
-    /**
-       Build a mutable Morphology from a read-only morphology
-    **/
+    /// Build a mutable Morphology from a read-only morphology
     explicit Morphology(const morphio::Morphology& morphology, unsigned int options = NO_MODIFIER);
 
     virtual ~Morphology();
 
-    /**
-       Returns all section ids at the tree root
-    **/
-    inline const std::vector<std::shared_ptr<Section>>& rootSections() const noexcept;
+    /// Returns all section ids at the tree root
+    const std::vector<std::shared_ptr<Section>>& rootSections() const noexcept {
+        return _rootSections;
+    }
 
-    /**
-       Returns the dictionary id -> Section for this tree
-    **/
-    inline const std::map<uint32_t, std::shared_ptr<Section>>& sections() const noexcept;
-
-    /**
-       Returns a shared pointer on the Soma
-
-       Note: multiple morphologies can share the same Soma instance
-    **/
-    inline std::shared_ptr<Soma>& soma() noexcept;
+    /// Returns the dictionary id -> Section for this tree
+    const std::map<uint32_t, std::shared_ptr<Section>>& sections() const noexcept {
+        return _sections;
+    }
 
     /**
        Returns a shared pointer on the Soma
 
        Note: multiple morphologies can share the same Soma instance
     **/
-    inline const std::shared_ptr<Soma>& soma() const noexcept;
+    std::shared_ptr<Soma>& soma() noexcept {
+        return _soma;
+    }
 
     /**
-     * Return the mitochondria container class
-     **/
-    inline Mitochondria& mitochondria() noexcept;
-    /**
-     * Return the mitochondria container class
-     **/
-    inline const Mitochondria& mitochondria() const noexcept;
+       Returns a shared pointer on the Soma
 
-    /**
-     * Return the endoplasmic reticulum container class
-     **/
-    inline EndoplasmicReticulum& endoplasmicReticulum() noexcept;
-    /**
-     * Return the endoplasmic reticulum container class
-     **/
-    inline const EndoplasmicReticulum& endoplasmicReticulum() const noexcept;
+       Note: multiple morphologies can share the same Soma instance
+    **/
+    const std::shared_ptr<Soma>& soma() const noexcept {
+        return _soma;
+    }
 
-    /**
-     * Return the annotation object
-     **/
-    inline const std::vector<Property::Annotation>& annotations() const noexcept;
+    /// Return the mitochondria container class
+    Mitochondria& mitochondria() noexcept {
+        return _mitochondria;
+    }
 
-    /**
-     * Return the markers from the ASC file
-     **/
-    inline const std::vector<Property::Marker>& markers() const noexcept;
+    /// Return the mitochondria container class
+    const Mitochondria& mitochondria() const noexcept {
+        return _mitochondria;
+    }
+
+    /// Return the endoplasmic reticulum container class
+    EndoplasmicReticulum& endoplasmicReticulum() noexcept {
+        return _endoplasmicReticulum;
+    }
+    ///
+    /// Return the endoplasmic reticulum container class
+    const EndoplasmicReticulum& endoplasmicReticulum() const noexcept {
+        return _endoplasmicReticulum;
+    }
+
+    /// Return the annotation object
+    const std::vector<Property::Annotation>& annotations() const noexcept {
+        return _cellProperties->_annotations;
+    }
+
+    /// Return the markers from the ASC file
+    const std::vector<Property::Marker>& markers() const noexcept {
+        return _cellProperties->_markers;
+    }
 
     /**
        Get the shared pointer for the given section
 
        Note: multiple morphologies can share the same Section instances.
     **/
-    inline const std::shared_ptr<Section>& section(uint32_t id) const;
+    const std::shared_ptr<Section>& section(uint32_t id) const {
+        return _sections.at(id);
+    }
 
     /**
        Depth first iterator starting at a given section id
@@ -127,12 +132,6 @@ class Morphology
     **/
     breadth_iterator breadth_begin() const;
     breadth_iterator breadth_end() const;
-
-    ////////////////////////////////////////////////////////////////////////////////
-    //
-    //   Tree manipulation methods
-    //
-    ////////////////////////////////////////////////////////////////////////////////
 
     /**
        Delete the given section
@@ -159,40 +158,39 @@ class Morphology
     std::shared_ptr<Section> appendRootSection(const std::shared_ptr<Section>& section,
                                                bool recursive = false);
 
-    /**
-       Append a root Section
-    **/
+    /// Append a root Section
     std::shared_ptr<Section> appendRootSection(const Property::PointLevel&,
                                                SectionType sectionType);
 
     void applyModifiers(unsigned int modifierFlags);
 
-    /**
-     * Return the soma type
-     **/
-    inline SomaType somaType() const noexcept;
+    /// Return the soma type
+    SomaType somaType() const noexcept {
+        return _soma->type();
+    }
 
-    /**
-     * Return the cell family (neuron or glia)
-     **/
-    inline CellFamily cellFamily() const noexcept;
+    /// Return the cell family (neuron or glia)
+    CellFamily cellFamily() const noexcept {
+        return _cellProperties->_cellFamily;
+    }
 
-    /**
-     * Return the version
-     **/
-    inline MorphologyVersion version() const noexcept;
+    /// Return the version
+    MorphologyVersion version() const noexcept {
+        return _cellProperties->_version;
+    }
 
-    /**
-     * Write file to H5, SWC, ASC format depending on filename extension
-     **/
+    /// Write file to H5, SWC, ASC format depending on filename extension
     void write(const std::string& filename);
 
-    inline void addAnnotation(const morphio::Property::Annotation& annotation);
-    inline void addMarker(const morphio::Property::Marker& marker);
+    void addAnnotation(const morphio::Property::Annotation& annotation) {
+        _cellProperties->_annotations.push_back(annotation);
+    }
 
-    /**
-       Return the data structure used to create read-only morphologies
-    **/
+    void addMarker(const morphio::Property::Marker& marker) {
+        _cellProperties->_markers.push_back(marker);
+    }
+
+    /// Return the data structure used to create read-only morphologies
     Property::Properties buildReadOnly() const;
 
     /**
@@ -209,102 +207,34 @@ class Morphology
     void removeUnifurcations();
     void removeUnifurcations(const morphio::readers::DebugInfo& debugInfo);
 
-    /**
-       Used before writing to SWC to check that there is no unifurcation
-     **/
-    void _raiseIfUnifurcations();
+    std::shared_ptr<Soma> _soma;
+    std::shared_ptr<morphio::Property::CellLevel> _cellProperties;
+    EndoplasmicReticulum _endoplasmicReticulum;
+    morphio::Property::DendriticSpine::Level _dendriticSpineLevel;
 
-  public:
+  private:
+    std::vector<std::shared_ptr<Section>> _rootSections;
+    std::map<uint32_t, std::shared_ptr<Section>> _sections;
+
+    Mitochondria _mitochondria;
+
+    std::map<uint32_t, uint32_t> _parent;
+    std::map<uint32_t, std::vector<std::shared_ptr<Section>>> _children;
+
+    uint32_t _counter = 0;
+
+    uint32_t _register(const std::shared_ptr<Section>&);
+    morphio::readers::ErrorMessages _err;
+
+    void eraseByValue(std::vector<std::shared_ptr<Section>>& vec,
+                      const std::shared_ptr<Section> section);
+
     friend class Section;
     friend void modifiers::nrn_order(morphio::mut::Morphology& morpho);
     friend bool diff(const Morphology& left,
                      const Morphology& right,
                      morphio::enums::LogLevel verbose);
-    morphio::readers::ErrorMessages _err;
-
-    uint32_t _register(const std::shared_ptr<Section>&);
-
-    uint32_t _counter = 0;
-    std::shared_ptr<Soma> _soma;
-    std::shared_ptr<morphio::Property::CellLevel> _cellProperties;
-    std::vector<std::shared_ptr<Section>> _rootSections;
-    std::map<uint32_t, std::shared_ptr<Section>> _sections;
-
-    Mitochondria _mitochondria;
-    EndoplasmicReticulum _endoplasmicReticulum;
-    morphio::Property::DendriticSpine::Level _dendriticSpineLevel;
-
-    std::map<uint32_t, uint32_t> _parent;
-    std::map<uint32_t, std::vector<std::shared_ptr<Section>>> _children;
-
-  private:
-    void eraseByValue(std::vector<std::shared_ptr<Section>>& vec,
-                      const std::shared_ptr<Section> section);
 };
-
-inline const std::vector<std::shared_ptr<Section>>& Morphology::rootSections() const noexcept {
-    return _rootSections;
-}
-
-inline const std::map<uint32_t, std::shared_ptr<Section>>& Morphology::sections() const noexcept {
-    return _sections;
-}
-
-inline std::shared_ptr<Soma>& Morphology::soma() noexcept {
-    return _soma;
-}
-
-inline const std::shared_ptr<Soma>& Morphology::soma() const noexcept {
-    return _soma;
-}
-
-inline Mitochondria& Morphology::mitochondria() noexcept {
-    return _mitochondria;
-}
-
-inline const Mitochondria& Morphology::mitochondria() const noexcept {
-    return _mitochondria;
-}
-
-inline EndoplasmicReticulum& Morphology::endoplasmicReticulum() noexcept {
-    return _endoplasmicReticulum;
-}
-
-inline const EndoplasmicReticulum& Morphology::endoplasmicReticulum() const noexcept {
-    return _endoplasmicReticulum;
-}
-
-inline const std::shared_ptr<Section>& Morphology::section(uint32_t id) const {
-    return _sections.at(id);
-}
-
-inline SomaType Morphology::somaType() const noexcept {
-    return _soma->type();
-}
-
-inline const std::vector<Property::Annotation>& Morphology::annotations() const noexcept {
-    return _cellProperties->_annotations;
-}
-
-inline const std::vector<Property::Marker>& Morphology::markers() const noexcept {
-    return _cellProperties->_markers;
-}
-
-inline CellFamily Morphology::cellFamily() const noexcept {
-    return _cellProperties->_cellFamily;
-}
-
-inline MorphologyVersion Morphology::version() const noexcept {
-    return _cellProperties->_version;
-}
-
-inline void Morphology::addAnnotation(const morphio::Property::Annotation& annotation) {
-    _cellProperties->_annotations.push_back(annotation);
-}
-
-inline void Morphology::addMarker(const morphio::Property::Marker& marker) {
-    _cellProperties->_markers.push_back(marker);
-}
 
 }  // namespace mut
 }  // namespace morphio


### PR DESCRIPTION
* make more members private (still too many public)
* collapse single line implementations into class declaration
* make documentation `brief`