### PR TITLE
The SWC format string used in `sscanf` is unnecessarily clamping the …

### DIFF
--- a/src/readers/morphologySWC.cpp
+++ b/src/readers/morphologySWC.cpp
@@ -21,9 +21,9 @@ bool _ignoreLine(const std::string& line) {
 
 morphio::readers::Sample readSample(const char* line, unsigned int lineNumber_) {
 #ifdef MORPHIO_USE_DOUBLE
-    const char *const format = "%20u%20d%20lg%20lg%20lg%20lg%20d";
+    const char* const format = "%u%d%lg%lg%lg%lg%d";
 #else
-    const char *const format = "%20u%20d%20f%20f%20f%20f%20d";
+    const char* const format = "%u%d%f%f%f%f%d";
 #endif
 
     morphio::floatType radius = -1.;

--- a/tests/data/simple.swc
+++ b/tests/data/simple.swc
@@ -29,4 +29,5 @@
  6 2  0  0 0 1.  1
  7 2  0 -4 0 1.  6
  8 2  6 -4 0 2.  7
- 9 2 -5 -4 0 2.  7
+ 9 2 -5 -4 0 2.0000000000000000000000000000000000000000000000000000000000000  7
+# long value for radius is to make sure SWC parser accepts long values


### PR DESCRIPTION
…size of allowed inputs

* fixes #419