### PR TITLE
Fix failing tests for macos-latest that uses python3.11

### DIFF
--- a/.github/workflows/publish-sdist-wheels.yml
+++ b/.github/workflows/publish-sdist-wheels.yml
@@ -84,7 +84,7 @@ jobs:
             brew update
             brew --version
             brew install hdf5
-          CIBW_ENVIRONMENT: PIP_NO_BINARY=h5py PIP_NO_CACHE_DIR=off
+          CIBW_ENVIRONMENT: PIP_NO_BINARY="h5py" PIP_NO_CACHE_DIR="off"
         run: |
           export HDF5_DIR=$(brew --prefix hdf5)
 

--- a/.github/workflows/publish-sdist-wheels.yml
+++ b/.github/workflows/publish-sdist-wheels.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.9'
+          python-version: '3.7'
 
       - name: Install cibuildwheel
         run: |
@@ -83,11 +83,11 @@ jobs:
           CIBW_BEFORE_BUILD: |
             brew update
             brew --version
+            brew install cmake
             brew install hdf5
-          CIBW_ENVIRONMENT: PIP_NO_BINARY="h5py" PIP_NO_CACHE_DIR="off"
         run: |
           export HDF5_DIR=$(brew --prefix hdf5)
-
+          echo $HDF5_DIR
           python -m cibuildwheel --output-dir dist
 
       - name: Build wheels Windows

--- a/.github/workflows/publish-sdist-wheels.yml
+++ b/.github/workflows/publish-sdist-wheels.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: '3.9'
 
       - name: Install cibuildwheel
         run: |

--- a/.github/workflows/publish-sdist-wheels.yml
+++ b/.github/workflows/publish-sdist-wheels.yml
@@ -83,9 +83,7 @@ jobs:
           CIBW_BEFORE_BUILD: |
             brew update
             brew --version
-            brew install cmake
             brew install hdf5
-            HDF5_DIR=$(brew --prefix hdf5) python -m pip install --no-binary h5py h5py
         run: |
           python -m cibuildwheel --output-dir dist
 

--- a/.github/workflows/publish-sdist-wheels.yml
+++ b/.github/workflows/publish-sdist-wheels.yml
@@ -85,9 +85,8 @@ jobs:
             brew --version
             brew install cmake
             brew install hdf5
+            HDF5_DIR=$(brew --prefix hdf5) python -m pip install --no-binary h5py h5py
         run: |
-          export HDF5_DIR=$(brew --prefix hdf5)
-          echo $HDF5_DIR
           python -m cibuildwheel --output-dir dist
 
       - name: Build wheels Windows

--- a/.github/workflows/publish-sdist-wheels.yml
+++ b/.github/workflows/publish-sdist-wheels.yml
@@ -85,6 +85,8 @@ jobs:
             brew --version
             brew install hdf5
         run: |
+          export HDF5_DIR=$(brew --prefix hdf5)
+
           python -m cibuildwheel --output-dir dist
 
       - name: Build wheels Windows

--- a/.github/workflows/publish-sdist-wheels.yml
+++ b/.github/workflows/publish-sdist-wheels.yml
@@ -84,6 +84,7 @@ jobs:
             brew update
             brew --version
             brew install hdf5
+          CIBW_ENVIRONMENT: PIP_NO_BINARY=h5py PIP_NO_CACHE_DIR=off
         run: |
           export HDF5_DIR=$(brew --prefix hdf5)
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-11]
         compiler:
           - {CC: clang, CXX: clang++}
           - {CC: gcc, CXX: g++}
@@ -37,7 +37,6 @@ jobs:
             brew --version
             brew install cmake || true  # macos image has cmake installed, but a new version may exist; ignore it if so
             brew install hdf5
-            export HDF5_DIR=$(brew --prefix hdf5)
 
       - name: Build and run unittests
         env:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-11]
+        os: [ubuntu-latest, macos-latest]
         compiler:
           - {CC: clang, CXX: clang++}
           - {CC: gcc, CXX: g++}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,7 +1,6 @@
 name: Run tests
 on: [pull_request, push]
 
-
 jobs:
   build:
     name: Run tests on ${{ matrix.os }}.${{ matrix.compiler.CC }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-11.7.0]
         compiler:
           - {CC: clang, CXX: clang++}
           - {CC: gcc, CXX: g++}
@@ -36,7 +36,6 @@ jobs:
             brew --version
             brew install cmake || true  # macos image has cmake installed, but a new version may exist; ignore it if so
             brew install hdf5
-            brew install pkg-config
 
       - name: Build and run unittests
         env:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -37,6 +37,7 @@ jobs:
             brew --version
             brew install cmake || true  # macos image has cmake installed, but a new version may exist; ignore it if so
             brew install hdf5
+            export HDF5_DIR=$(brew --prefix hdf5)
 
       - name: Build and run unittests
         env:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-11.7.0]
+        os: [ubuntu-latest, macos-latest]
         compiler:
           - {CC: clang, CXX: clang++}
           - {CC: gcc, CXX: g++}
@@ -24,6 +24,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: 'true'
+
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
 
       - name: Install packages on Linux
         if: runner.os == 'Linux'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,7 @@
 name: Run tests
 on: [pull_request, push]
 
+
 jobs:
   build:
     name: Run tests on ${{ matrix.os }}.${{ matrix.compiler.CC }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -37,7 +37,7 @@ jobs:
             brew --version
             brew install cmake || true  # macos image has cmake installed, but a new version may exist; ignore it if so
             brew install hdf5
-            export HDF5_DIR=$(brew --prefix hdf5)
+            brew install pkg-config
 
       - name: Build and run unittests
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,32 @@
 v3.3.4
 ======
 
+New Features:
+* Add operator-> for iterators, for better ergonomics (#408)
+* Allow SWC and ASC morphologies to be built from strings (#407)
+
 Fixes:
+* Fallback to using python 3.10 for ci tests (#430)
+* Fix sscanf clammping of allowed inputs (#420)
+* Fix section order after deleting section in mut morphology (#412)
+* Enable test mistakenly disabled (#418)
+* Freeze wheel build os versions (#391)
 * Fix wrong section order when section is deleted (#412)
+
+Improvements:
+* Remove travis configuration and badge (#428)
+* Update links to morphology documentation (#424)
+* Update pybind11 to v2.10.0 release (#425)
+* Cleanup tests (#421)
+* Cleanup mutable morphology and soma (#413, #414, #415)
+* Cleanup ascii reader (#405)
+* Use Catch2 builtins to approximate comparisons (#394)
+* Update lexertl14 to latest commit cd5a1f1 (#397)
+* Update HighFive to v2.4.1 (#406)
+* Update gsl-lite submodule to v0.40.0 (#395)
+* Use non-exceptional methods wherever possible (#389)*
+* Rebuild morphologies only when modifiers are passed (#392)
+
 
 v3.3.3
 ======

--- a/ci/python_test.sh
+++ b/ci/python_test.sh
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 
 set -euxo pipefail
 
@@ -36,6 +35,7 @@ deactivate
 DIST_DIR="$VENV/dist"
 mkdir -p "$DIST_DIR"
 create_venv
+$BIN/pip install --no-binary h5py h5py
 python3 setup.py sdist --dist-dir "$DIST_DIR"
 $BIN/pip install "$DIST_DIR"/MorphIO*.tar.gz
 $BIN/pip install -r tests/requirement_tests.txt

--- a/ci/python_test.sh
+++ b/ci/python_test.sh
@@ -13,17 +13,20 @@ function create_venv()
         set +u  # ignore errors in virtualenv's activate
         source "$VENV/bin/activate"
         set -u
-
-        which pip
-
-        pip install --upgrade pip setuptools wheel
     fi
 }
 
 # in tree install
 create_venv
-pip install .
-pip install -r tests/requirement_tests.txt
+
+BIN=$VENV/bin/
+
+$BIN/pip -v install .
+
+which $BIN/pip
+
+$BIN/pip install --upgrade pip setuptools wheel
+$BIN/pip install -r tests/requirement_tests.txt
 
 CURRENT=$(pwd)
 (cd .. && pytest ${CURRENT}/tests)
@@ -34,8 +37,8 @@ DIST_DIR="$VENV/dist"
 mkdir -p "$DIST_DIR"
 create_venv
 python3 setup.py sdist --dist-dir "$DIST_DIR"
-pip install "$DIST_DIR"/MorphIO*.tar.gz
-pip install -r tests/requirement_tests.txt
+$BIN/pip install "$DIST_DIR"/MorphIO*.tar.gz
+$BIN/pip install -r tests/requirement_tests.txt
 
 CURRENT=$(pwd)
 (cd .. && pytest ${CURRENT}/tests)

--- a/ci/python_test.sh
+++ b/ci/python_test.sh
@@ -36,9 +36,10 @@ DIST_DIR="$VENV/dist"
 mkdir -p "$DIST_DIR"
 create_venv
 
-python3 setup.py sdist --dist-dir "$DIST_DIR"
-python3 -mpip install "$DIST_DIR"/MorphIO*.tar.gz
-python3 -mpip install -r tests/requirement_tests.txt
+python3 -m pip install build
+python3 -m build . --outdir "$DIST_DIR"
+python3 -m pip install "$DIST_DIR"/MorphIO*.tar.gz
+python3 -m pip install -r tests/requirement_tests.txt
 
 pushd $(pwd)/tests
 pytest .

--- a/ci/python_test.sh
+++ b/ci/python_test.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 
 set -euxo pipefail
 
@@ -38,6 +39,7 @@ mkdir -p "$DIST_DIR"
 create_venv
 
 python3 setup.py sdist --dist-dir "$DIST_DIR"
+python3 -mpip install "$DIST_DIR"/MorphIO*.tar.gz
 python3 -mpip install -r tests/requirement_tests.txt
 
 pushd $(pwd)/tests

--- a/ci/python_test.sh
+++ b/ci/python_test.sh
@@ -40,6 +40,7 @@ create_venv
 
 python3 setup.py sdist --dist-dir "$DIST_DIR"
 python3 -mpip install "$DIST_DIR"/MorphIO*.tar.gz
+python3 -mpip install --no-binary h5py h5py
 python3 -mpip install -r tests/requirement_tests.txt
 
 pushd $(pwd)/tests

--- a/ci/python_test.sh
+++ b/ci/python_test.sh
@@ -40,7 +40,6 @@ create_venv
 
 python3 setup.py sdist --dist-dir "$DIST_DIR"
 python3 -mpip install "$DIST_DIR"/MorphIO*.tar.gz
-python3 -mpip install --no-binary h5py h5py
 python3 -mpip install -r tests/requirement_tests.txt
 
 pushd $(pwd)/tests

--- a/ci/python_test.sh
+++ b/ci/python_test.sh
@@ -15,8 +15,6 @@ function create_venv()
         set -u
 
         $VENV/bin/pip install --upgrade pip setuptools wheel
-
-        which $VENV/bin/pip
     fi
 }
 

--- a/ci/python_test.sh
+++ b/ci/python_test.sh
@@ -12,33 +12,34 @@ function create_venv()
         set +u  # ignore errors in virtualenv's activate
         source "$VENV/bin/activate"
         set -u
+
+        $VENV/bin/pip install --upgrade pip setuptools wheel
+
+        which $VENV/bin/pip
     fi
 }
 
 # in tree install
 create_venv
 
-BIN=$VENV/bin/
+$VENV/bin/pip -v install --force .
+$VENV/bin/pip -v install -r tests/requirement_tests.txt
 
-$BIN/pip -v install .
 
-which $BIN/pip
+pushd $(pwd)/tests
+pytest .
+popd
 
-$BIN/pip install --upgrade pip setuptools wheel
-$BIN/pip install -r tests/requirement_tests.txt
-
-CURRENT=$(pwd)
-(cd .. && pytest ${CURRENT}/tests)
 deactivate
 
 # sdist install
 DIST_DIR="$VENV/dist"
 mkdir -p "$DIST_DIR"
 create_venv
-$BIN/pip install --no-binary h5py h5py
-python3 setup.py sdist --dist-dir "$DIST_DIR"
-$BIN/pip install "$DIST_DIR"/MorphIO*.tar.gz
-$BIN/pip install -r tests/requirement_tests.txt
 
-CURRENT=$(pwd)
-(cd .. && pytest ${CURRENT}/tests)
+python3 setup.py sdist --dist-dir "$DIST_DIR"
+python3 -mpip install -r tests/requirement_tests.txt
+
+pushd $(pwd)/tests
+pytest .
+popd


### PR DESCRIPTION
With `macos-latest`, i.e. `macos-11.7.1` python was upgraded from 3.10 to 3.11:
https://github.com/actions/runner-images/commit/1f84dd7159610d519a3bdc2beff2352b41a9355f#diff-e68d4f6e862f03aa8800c0d5de1c1072dd2d01553ca0986d818f012c932a25a4L34
which results in trying to build h5py from source for the test runs, , given there are no wheels yet,  and herefore fails.

Setting up python to 3.10 for the tests solves this issue.
