### PR TITLE
Prevent `pytest` from picking up pybind11 tests.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths =
+    tests


### PR DESCRIPTION
When simply running `pytest` after a performing `pip install -e .` I get the following errors:
```
binds/python/pybind11/tests/conftest.py:16: in <module>
    import pybind11_tests
E   ModuleNotFoundError: No module named 'pybind11_tests'
```
which means it's picking up the pybind11 tests and fails. This PR proposes to limit the folders pytest considers to `tests`.