### PR TITLE
Revert installing Python module systemwide.

### DIFF
--- a/binds/python/CMakeLists.txt
+++ b/binds/python/CMakeLists.txt
@@ -17,10 +17,3 @@ target_link_libraries(_morphio
     PRIVATE morphio_static
     PRIVATE pybind11::module
 )
-
-find_package (Python3)
-
-install(
-  TARGETS _morphio
-  LIBRARY DESTINATION ${Python3_SITEARCH}/morphio/
-)


### PR DESCRIPTION
The lines

    install(
      TARGETS _morphio
      LIBRARY DESTINATION ${Python3_SITEARCH}/morphio/
    )

cause CMake to find the directory where Python modules are installed. This would be the systemwide directory if one is simply building with the systemwide Python. If one has a venv active it'll install into that virtual environment.

Note that `CMAKE_INSTALL_PREFIX` doesn't affect where the module will be installed. Therefore, this will cause build/installation failure.

Installing into a venv is questionable, because that's the responsibility of the Python package manager. Which will do so correctly without the additional CMake  `install` statement.

Finally, even if the install succeeds, it  only installs the `lib*.so` without any `__init__.py` files. Therefore, it leads to a broken installation, e.g.

    python -c "import morphio; morphio.Soma"

will successfully import `morphio` but there won't be any `morphio.Soma`, because that's handled via `__init__.py`