### PR TITLE
Have test succeed on all architectures

### DIFF
--- a/tests/test_utilities.cpp
+++ b/tests/test_utilities.cpp
@@ -153,7 +153,7 @@ TEST_CASE("morphio::shared_utils") {
         const std::vector<floatType> diameters = {0.1, 0.1, 0.1};
         Point expected{1 / floatType{3}, 2 / floatType{3}, 2 / floatType{3}};
         CHECK(centerOfGravity(points) == expected);
-        CHECK(maxDistanceToCenterOfGravity(points) == 1);
+        CHECK(maxDistanceToCenterOfGravity(points) == Approx(1));
         CHECK_THROWS(_somaSurface(SOMA_SIMPLE_CONTOUR, diameters, points));
     }
     /* CHECK(_somaSurface(SOMA_SINGLE_POINT, diameters, points) == Approx(0.0)); */


### PR DESCRIPTION
Updating MorphIO to 3.3.6 I discovered that one test kept failing
on secondary architectures (aarch64, ppc64le and s390x).

The error message was:

```
/builddir/build/BUILD/MorphIO-3.3.6/tests/test_utilities.cpp:151: FAILED:
  CHECK( maxDistanceToCenterOfGravity(points) == 1 )
with expansion:
  1.0 == 1
```
