### PR TITLE
Fix incorrect warning types for `OnlyChild` and `DisconnectedNeurite`

### DIFF
--- a/binds/python/bind_warnings_exceptions.cpp
+++ b/binds/python/bind_warnings_exceptions.cpp
@@ -87,9 +87,8 @@ void bind_warnings_exceptions(py::module& m) {
 #define QUOTE(a) #a
 #define C(name) \
     py::class_<name, WarningMessage, std::shared_ptr<name>>(m, QUOTE(name), "WarningMessage")
-    C(WarningZeroDiameter).def_readonly("line_number", &WarningZeroDiameter::lineNumber, "ibid");
-    C(WarningDisconnectedNeurite)
-        .def_readonly("line_number", &WarningDisconnectedNeurite::lineNumber, "ibid");
+    C(ZeroDiameter).def_readonly("line_number", &ZeroDiameter::lineNumber, "ibid");
+    C(DisconnectedNeurite).def_readonly("line_number", &DisconnectedNeurite::lineNumber, "ibid");
     (void) C(NoSomaFound);
     C(SomaNonConform).def_readonly("description", &SomaNonConform::description, "ibid");
     C(WrongRootPoint).def_readonly("line_numbers", &WrongRootPoint::lineNumbers, "ibid");

--- a/binds/python/generated/docstrings.h
+++ b/binds/python/generated/docstrings.h
@@ -104,6 +104,18 @@ static const char *mkd_doc_morphio_DendriticSpine_soma = R"doc()doc";
 
 static const char *mkd_doc_morphio_DendriticSpine_somaType = R"doc()doc";
 
+static const char *mkd_doc_morphio_DisconnectedNeurite = R"doc()doc";
+
+static const char *mkd_doc_morphio_DisconnectedNeurite_DisconnectedNeurite = R"doc()doc";
+
+static const char *mkd_doc_morphio_DisconnectedNeurite_errorLevel = R"doc()doc";
+
+static const char *mkd_doc_morphio_DisconnectedNeurite_lineNumber = R"doc()doc";
+
+static const char *mkd_doc_morphio_DisconnectedNeurite_msg = R"doc()doc";
+
+static const char *mkd_doc_morphio_DisconnectedNeurite_warning = R"doc()doc";
+
 static const char *mkd_doc_morphio_EndoplasmicReticulum =
 R"doc(The entry-point class to access endoplasmic reticulum data
 
@@ -888,18 +900,6 @@ static const char *mkd_doc_morphio_UnknownFileType = R"doc()doc";
 
 static const char *mkd_doc_morphio_UnknownFileType_UnknownFileType = R"doc()doc";
 
-static const char *mkd_doc_morphio_WarningDisconnectedNeurite = R"doc()doc";
-
-static const char *mkd_doc_morphio_WarningDisconnectedNeurite_WarningDisconnectedNeurite = R"doc()doc";
-
-static const char *mkd_doc_morphio_WarningDisconnectedNeurite_errorLevel = R"doc()doc";
-
-static const char *mkd_doc_morphio_WarningDisconnectedNeurite_lineNumber = R"doc()doc";
-
-static const char *mkd_doc_morphio_WarningDisconnectedNeurite_msg = R"doc()doc";
-
-static const char *mkd_doc_morphio_WarningDisconnectedNeurite_warning = R"doc()doc";
-
 static const char *mkd_doc_morphio_WarningHandler = R"doc()doc";
 
 static const char *mkd_doc_morphio_WarningHandlerCollector =
@@ -992,18 +992,6 @@ static const char *mkd_doc_morphio_WarningMessage_uri = R"doc()doc";
 
 static const char *mkd_doc_morphio_WarningMessage_warning = R"doc()doc";
 
-static const char *mkd_doc_morphio_WarningZeroDiameter = R"doc()doc";
-
-static const char *mkd_doc_morphio_WarningZeroDiameter_WarningZeroDiameter = R"doc()doc";
-
-static const char *mkd_doc_morphio_WarningZeroDiameter_errorLevel = R"doc()doc";
-
-static const char *mkd_doc_morphio_WarningZeroDiameter_lineNumber = R"doc()doc";
-
-static const char *mkd_doc_morphio_WarningZeroDiameter_msg = R"doc()doc";
-
-static const char *mkd_doc_morphio_WarningZeroDiameter_warning = R"doc()doc";
-
 static const char *mkd_doc_morphio_WriteEmptyMorphology = R"doc()doc";
 
 static const char *mkd_doc_morphio_WriteEmptyMorphology_WriteEmptyMorphology = R"doc()doc";
@@ -1063,6 +1051,18 @@ static const char *mkd_doc_morphio_WrongRootPoint_lineNumbers = R"doc()doc";
 static const char *mkd_doc_morphio_WrongRootPoint_msg = R"doc()doc";
 
 static const char *mkd_doc_morphio_WrongRootPoint_warning = R"doc()doc";
+
+static const char *mkd_doc_morphio_ZeroDiameter = R"doc()doc";
+
+static const char *mkd_doc_morphio_ZeroDiameter_ZeroDiameter = R"doc()doc";
+
+static const char *mkd_doc_morphio_ZeroDiameter_errorLevel = R"doc()doc";
+
+static const char *mkd_doc_morphio_ZeroDiameter_lineNumber = R"doc()doc";
+
+static const char *mkd_doc_morphio_ZeroDiameter_msg = R"doc()doc";
+
+static const char *mkd_doc_morphio_ZeroDiameter_warning = R"doc()doc";
 
 static const char *mkd_doc_morphio_children = R"doc(Return a list of children sections)doc";
 

--- a/include/morphio/warning_handling.h
+++ b/include/morphio/warning_handling.h
@@ -38,8 +38,8 @@ struct WarningMessage {
     std::string uri;
 };
 
-struct WarningZeroDiameter: public WarningMessage {
-    WarningZeroDiameter(std::string uri_, uint64_t lineNumber_)
+struct ZeroDiameter: public WarningMessage {
+    ZeroDiameter(std::string uri_, uint64_t lineNumber_)
         : WarningMessage(std::move(uri_))
         , lineNumber(lineNumber_) {}
     morphio::enums::Warning warning() const final {
@@ -54,12 +54,12 @@ struct WarningZeroDiameter: public WarningMessage {
     uint64_t lineNumber;
 };
 
-struct WarningDisconnectedNeurite: public WarningMessage {
-    WarningDisconnectedNeurite(std::string uri_, uint64_t lineNumber_)
+struct DisconnectedNeurite: public WarningMessage {
+    DisconnectedNeurite(std::string uri_, uint64_t lineNumber_)
         : WarningMessage(std::move(uri_))
         , lineNumber(lineNumber_) {}
     Warning warning() const final {
-        return Warning::ZERO_DIAMETER;
+        return Warning::DISCONNECTED_NEURITE;
     }
     morphio::readers::ErrorLevel errorLevel = morphio::readers::ErrorLevel::WARNING;
     std::string msg() const final {
@@ -158,7 +158,7 @@ struct OnlyChild: public WarningMessage {
         , parentId(parentId_)
         , childId(childId_) {}
     Warning warning() const final {
-        return Warning::APPENDING_EMPTY_SECTION;
+        return Warning::ONLY_CHILD;
     }
     morphio::readers::ErrorLevel errorLevel = morphio::readers::ErrorLevel::WARNING;
     std::string msg() const final {

--- a/src/readers/morphologySWC.cpp
+++ b/src/readers/morphologySWC.cpp
@@ -207,7 +207,7 @@ class SWCBuilder
 
     void warnIfDisconnectedNeurite(const SWCSample& sample, WarningHandler* h) {
         if (sample.parentId == SWC_ROOT && sample.type != SECTION_SOMA) {
-            h->emit(std::make_shared<WarningDisconnectedNeurite>(uri, sample.lineNumber));
+            h->emit(std::make_shared<DisconnectedNeurite>(uri, sample.lineNumber));
         }
     }
 
@@ -240,7 +240,7 @@ class SWCBuilder
 
     void warnIfZeroDiameter(const SWCSample& sample, WarningHandler* h) {
         if (sample.diameter < morphio::epsilon) {
-            h->emit(std::make_shared<WarningZeroDiameter>(uri, sample.lineNumber));
+            h->emit(std::make_shared<ZeroDiameter>(uri, sample.lineNumber));
         }
     }
 


### PR DESCRIPTION
* Take the opportunity to fix up the redundant `Warning` prefix