### PR TITLE
Make ThreePointSoma use relative tolerance

### DIFF
--- a/src/shared_utils.cpp
+++ b/src/shared_utils.cpp
@@ -97,10 +97,7 @@ ThreePointSomaStatus checkNeuroMorphoSoma(const std::array<Point, 3>& points, fl
 
     auto withinRelativeEpsilon = [](floatType a, floatType b) {
         floatType diff = std::fabs(a - b);
-        a = std::fabs(a);
-        b = std::fabs(b);
-        float largest = (b > a) ? b : a;
-        return diff <= largest * FLT_EPSILON;
+        return diff <= std::max(std::fabs(a), std::fabs(b)) * FLT_EPSILON;
     };
 
     std::bitset<3> column_mask = {};

--- a/src/shared_utils.cpp
+++ b/src/shared_utils.cpp
@@ -2,8 +2,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <algorithm>  // std::max
 #include <bitset>
 #include <cfloat> // FLT_EPSILON
+#include <cmath>  // std::abs
 
 #include "error_message_generation.h"
 #include "shared_utils.hpp"
@@ -96,8 +98,8 @@ ThreePointSomaStatus checkNeuroMorphoSoma(const std::array<Point, 3>& points, fl
     //  3 1 x y (z - r) r  1
 
     auto withinRelativeEpsilon = [](floatType a, floatType b) {
-        floatType diff = std::fabs(a - b);
-        return diff <= std::max(std::fabs(a), std::fabs(b)) * FLT_EPSILON;
+        floatType diff = std::abs(a - b);
+        return diff <= std::max(std::abs(a), std::abs(b)) * FLT_EPSILON;
     };
 
     std::bitset<3> column_mask = {};

--- a/src/shared_utils.cpp
+++ b/src/shared_utils.cpp
@@ -4,8 +4,8 @@
  */
 #include <algorithm>  // std::max
 #include <bitset>
-#include <cfloat> // FLT_EPSILON
 #include <cmath>  // std::abs
+#include <limits>  // std::numeric_limits
 
 #include "error_message_generation.h"
 #include "shared_utils.hpp"
@@ -99,7 +99,8 @@ ThreePointSomaStatus checkNeuroMorphoSoma(const std::array<Point, 3>& points, fl
 
     auto withinRelativeEpsilon = [](floatType a, floatType b) {
         floatType diff = std::abs(a - b);
-        return diff <= std::max(std::abs(a), std::abs(b)) * FLT_EPSILON;
+        return diff <=
+               std::max(std::abs(a), std::abs(b)) * std::numeric_limits<floatType>::epsilon();
     };
 
     std::bitset<3> column_mask = {};

--- a/src/shared_utils.cpp
+++ b/src/shared_utils.cpp
@@ -4,7 +4,7 @@
  */
 #include <algorithm>  // std::max
 #include <bitset>
-#include <cmath>  // std::abs
+#include <cmath>  // std::fabs
 #include <limits>  // std::numeric_limits
 
 #include "error_message_generation.h"
@@ -72,6 +72,7 @@ bool is_regular_file(const std::string& path) {
 std::string join_path(const std::string& dirname, const std::string& filename) {
     return (ghc::filesystem::path(dirname) / filename).string();
 }
+
 namespace details {
 ThreePointSomaStatus checkNeuroMorphoSoma(const std::array<Point, 3>& points, floatType radius) {
     //  NeuroMorpho is the main provider of morphologies, but they
@@ -98,9 +99,9 @@ ThreePointSomaStatus checkNeuroMorphoSoma(const std::array<Point, 3>& points, fl
     //  3 1 x y (z - r) r  1
 
     auto withinRelativeEpsilon = [](floatType a, floatType b) {
-        floatType diff = std::abs(a - b);
+        floatType diff = std::fabs(a - b);
         return diff <=
-               std::max(std::abs(a), std::abs(b)) * std::numeric_limits<floatType>::epsilon();
+               (std::max)(std::fabs(a), std::fabs(b)) * std::numeric_limits<floatType>::epsilon();
     };
 
     std::bitset<3> column_mask = {};

--- a/tests/test_1_swc.py
+++ b/tests/test_1_swc.py
@@ -305,8 +305,10 @@ def test_soma_type_3_point(tmp_path):
                           3 1 0  0 0 3.0  1 # PID is 1''')
             assert (Morphology(content, extension='swc').soma_type ==
                     SomaType.SOMA_NEUROMORPHO_THREE_POINT_CYLINDERS)
-            assert strip_color_codes(err.getvalue()).strip() == \
-                    '$STRING$:0:warning\nOnly one column has the same coordinates.'
+            assert strip_color_codes(err.getvalue()).strip() == (
+                    "$STRING$:0:warning\n"
+                    "Three Point Soma: Only one column has the same coordinates."
+                    )
 
     with captured_output() as (_, err):
         with ostream_redirect(stdout=True, stderr=True):
@@ -315,8 +317,10 @@ def test_soma_type_3_point(tmp_path):
                           3 1 0  0 0 3.0  1 # PID is 1''')
             assert (Morphology(content, extension='swc').soma_type ==
                          SomaType.SOMA_NEUROMORPHO_THREE_POINT_CYLINDERS)
-            assert strip_color_codes(err.getvalue()).strip() == \
-                    '$STRING$:0:warning\nThe non-constant columns is not offset by +/- the radius from the initial sample.'
+            assert strip_color_codes(err.getvalue()).strip() == (
+                    "$STRING$:0:warning\n"
+                    "Three Point Soma: The non-constant columns is not offset by +/- the radius from the initial sample."
+                    )
 
     # If this configuration is not respected -> SOMA_CYLINDERS
     content = ( '''1 1 0 0 0 3.0 -1

--- a/tests/test_1_swc.py
+++ b/tests/test_1_swc.py
@@ -326,6 +326,18 @@ def test_soma_type_3_point(tmp_path):
             SomaType.SOMA_CYLINDERS)
 
 
+def test_swc_threepoint_soma_tolerance():
+    # from https://github.com/BlueBrain/MorphIO/issues/492
+    contents = """
+    1 1 5789.674999999998 1322.85 2846.65 5.165118027 -1
+    2 1 5789.674999999998 1317.6848819729996 2846.65 5.165118027 1
+    3 1 5789.674999999998 1328.015118027 2846.65 5.165118027 1
+    """
+    warnings = morphio.WarningHandlerCollector()
+    Morphology(contents, extension="swc", warning_handler=warnings)
+    assert len(warnings.get_all()) == 0
+
+
 def test_read_weird_ids():
     '''The ordering of IDs is not required'''
     content = ('''10000 3 0 0 5 0.5 100 # neurite 4th point

--- a/tests/test_1_swc.py
+++ b/tests/test_1_swc.py
@@ -341,6 +341,35 @@ def test_swc_threepoint_soma_tolerance():
     Morphology(contents, extension="swc", warning_handler=warnings)
     assert len(warnings.get_all()) == 0
 
+    contents = """
+    1 1 10000 10000             10000 100.999999999999999999 -1
+    2 1 10000 9899.000000000001 10000 100.999999999999999999 1
+    3 1 10000 10100.99999999999 10000 100.999999999999999999 1
+    """
+    warnings = morphio.WarningHandlerCollector()
+    Morphology(contents, extension="swc", warning_handler=warnings)
+    assert len(warnings.get_all()) == 0
+
+    # This still passes, even with the third point being off by 0.0000008 which seems reasonable
+    contents = """
+    1 1 10000 10000             10000 100.999999999999999999 -1
+    2 1 10000 9899.000000000001 10000 100.999999999999999999 1
+    3 1 10000 10100.99999911111 10000 100.999999999999999999 1
+    """
+    warnings = morphio.WarningHandlerCollector()
+    Morphology(contents, extension="swc", warning_handler=warnings)
+    assert len(warnings.get_all()) == 0
+
+    # The third point being off by 0.0088888 creates warning
+    contents = """
+    1 1 10000 10000             10000 100.999999999999999999 -1
+    2 1 10000 9899.000000000001 10000 100.999999999999999999 1
+    3 1 10000 10100.99111111111 10000 100.999999999999999999 1
+    """
+    warnings = morphio.WarningHandlerCollector()
+    Morphology(contents, extension="swc", warning_handler=warnings)
+    assert len(warnings.get_all()) == 1
+
 
 def test_read_weird_ids():
     '''The ordering of IDs is not required'''


### PR DESCRIPTION
* Allows for `float32` builds of `morphio` to work with SWC morphologies that aren't centered at `0.0` or have precision that is truncated #492 
* make `Three point soma errors` more clear, fixes #491 
