### PR TITLE
Fix a test regression with pybind11 2.11.2, 2.12.1, 2.13.6+

### DIFF
--- a/tests/test_0_API.py
+++ b/tests/test_0_API.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import morphio
 
-
 def test_doc_exists():
     classes = [
         morphio.EndoplasmicReticulum,
@@ -18,9 +17,18 @@ def test_doc_exists():
         morphio.mut.Section,
         morphio.mut.Soma,
     ]
+
+    # we want to makes sure we never forget to add imports in the morphio.__init__
+    # however, sometimes pybind adds new functions in that namespace, this is the
+    # place to explicitly ignore them
+    ignored_methods = {
+        "_pybind11_conduit_v1_"
+    }
+
     for cls in classes:
         public_methods = (
-            method for method in dir(cls) if not method.startswith(("__", "_pybind11"))
+            method for method in dir(cls)
+            if not (method.startswith("__") or method in ignored_methods)
         )
         for method in public_methods:
             assert getattr(cls, method).__doc__, \

--- a/tests/test_0_API.py
+++ b/tests/test_0_API.py
@@ -19,7 +19,9 @@ def test_doc_exists():
         morphio.mut.Soma,
     ]
     for cls in classes:
-        public_methods = (method for method in dir(cls) if not method[:2] == '__')
+        public_methods = (
+            method for method in dir(cls) if not method.startswith(("__", "_pybind11"))
+        )
         for method in public_methods:
             assert getattr(cls, method).__doc__, \
                 'Public method {} of class {} is not documented !'.format(method, cls)


### PR DESCRIPTION
“A new `self._pybind11_conduit_v1_()` method is automatically added to all `py::class_`-wrapped types, to enable type-safe interoperability between different independent Python/C++ bindings systems, including pybind11 versions with different `PYBIND11_INTERNALS_VERSION`s.”

https://github.com/pybind/pybind11/releases/tag/v2.13.6

Ensure that `tests/test_0_API.py::test_doc_exists` does not see this as an undocumented API function.