### PR TITLE
Include <cstdint> for fixed-width integers in API headers

### DIFF
--- a/include/morphio/mitochondria.h
+++ b/include/morphio/mitochondria.h
@@ -4,6 +4,7 @@
  */
 #pragma once
 
+#include <cstdint>  // uint32_t
 #include <memory>
 #include <vector>
 

--- a/include/morphio/morphology.h
+++ b/include/morphio/morphology.h
@@ -4,6 +4,8 @@
  */
 #pragma once
 
+#include <cstdint>  // uint32_t
+
 #include <highfive/H5Group.hpp>
 
 #include <morphio/properties.h>

--- a/include/morphio/mut/endoplasmic_reticulum.h
+++ b/include/morphio/mut/endoplasmic_reticulum.h
@@ -4,6 +4,8 @@
  */
 #pragma once
 
+#include <cstdint>  // uint32_t
+
 #include <morphio/properties.h>
 #include <morphio/types.h>
 

--- a/include/morphio/mut/glial_cell.h
+++ b/include/morphio/mut/glial_cell.h
@@ -4,6 +4,8 @@
  */
 #pragma once
 
+#include <cstdint>  // uint32_t
+
 #include <string>  // std::string
 
 #include <morphio/mut/morphology.h>  // mut::Morphology

--- a/include/morphio/mut/mitochondria.h
+++ b/include/morphio/mut/mitochondria.h
@@ -4,6 +4,7 @@
  */
 #pragma once
 
+#include <cstdint>  // uint32_t
 #include <map>
 #include <memory>
 

--- a/include/morphio/mut/morphology.h
+++ b/include/morphio/mut/morphology.h
@@ -4,6 +4,7 @@
  */
 #pragma once
 
+#include <cstdint>  // uint32_t
 #include <map>
 #include <memory>
 #include <string>

--- a/include/morphio/mut/section.h
+++ b/include/morphio/mut/section.h
@@ -4,6 +4,8 @@
  */
 #pragma once
 
+#include <cstdint>  // uint32_t
+
 #include <morphio/properties.h>
 #include <morphio/section.h>
 #include <morphio/types.h>

--- a/include/morphio/properties.h
+++ b/include/morphio/properties.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>  // uint32_t
+#include <cstdint>  // int32_t, uint32_t
 
 #include <array>
 #include <map>

--- a/include/morphio/vasc/properties.h
+++ b/include/morphio/vasc/properties.h
@@ -4,6 +4,7 @@
  */
 #pragma once
 
+#include <cstdint>  // uint32_t
 #include <map>
 #include <string>  // std::string
 #include <vector>  // std::vector

--- a/include/morphio/vasc/section.h
+++ b/include/morphio/vasc/section.h
@@ -4,6 +4,7 @@
  */
 #pragma once
 
+#include <cstdint>  // uint32_t
 #include <iosfwd>  // std::ostream
 #include <memory>  // std::shared_ptr
 #include <vector>  // std::vector

--- a/include/morphio/vasc/vasculature.h
+++ b/include/morphio/vasc/vasculature.h
@@ -4,6 +4,7 @@
  */
 #pragma once
 
+#include <cstdint>  // uint32_t
 #include <memory>  // std::shared_ptr
 #include <string>  // std::string
 #include <vector>  // std::vector

--- a/include/morphio/warning_handling.h
+++ b/include/morphio/warning_handling.h
@@ -4,6 +4,7 @@
  */
 #pragma once
 
+#include <cstdint>  // int32_t, uint32_t, uint64_t
 #include <iostream>
 #include <memory>
 #include <set>


### PR DESCRIPTION
At least in the API headers, include `<cstdint>` everywhere that fixed-width integer types `int32_t`, `uint32_t`, or `uint64_t` are used. Including headers everywhere they are used avoids relying on indirectly including them via the C++ standard library, which tends to break with new compiler versions. This change doesn’t implement that idea project-wide even for `<cstdint>`, let alone in general, but it is enough to fix failure to build with GCC 15 (as observed in Fedora).